### PR TITLE
Updated kinematics section of the theory documentation

### DIFF
--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -117,10 +117,10 @@ Here, the kinematics matrix, :math:`K`, is defined as the linear transformation 
     p = K x
     :label: kinematics
 
-The relationship :math:`p(x)` is typically referred to as the *forward kinematics*.
+The relationship :math:`p(x)` is typically referred to as the *backward kinematics*, in the field of robotics. If the WEC were considered to be a robot it's hydrodynamic body would be equivalent to an endeffector represented in a global coordinate frame. The PTO positions would be equivalent to joint positions in local coordinates.
 The matrix :math:`K` has a size equal to the number of DOFs of the PTOs times the number of DOFs of the WEC.
 Note, however that the real kinematics might not be linear.
-Equation :eq:`kinematics` represents a linearization of :math:`p(x)` about the mean :math:`x=0` position, with the matrix :math:`K` being the Jacobian of :math:`p(x)` at :math:`x=0`.
+Equation :eq:`kinematics` represents a linearization of :math:`p(x)` about the mean :math:`x=0` position, with the matrix :math:`K` being the inverse Jacobian of :math:`p(x)` at :math:`x=0`.
 
 The transpose of :math:`K` is used to transform the PTO forces in PTO frame, :math:`f_p`, to the PTO forces on the WEC, :math:`f_w`:
 


### PR DESCRIPTION
## Description
The theory section on the kinematics was not in line with the robotics literature. We now added an equivalence between WEC and robot end effector.

## Type of PR
- [ ] Bug fix
- [ ] New feature
- [X] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [X] Authors read the [contribution guidelines](https://github.com/SNL-WaterPower/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [X] The pull request is from an issue branch (not main) on *your* fork, to the [main branch in WecOptTool](https://github.com/SNL-WaterPower/WecOptTool).
- [X] The authors have given the admins edit access
- [X] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [X] Modified the documentation if applicable
- [ ] Modified or added a new test
- [X] All tests pass
- [X] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Additional details
Include any relevant context and describe any validation and verification efforts.
