### PR TITLE
Added conda-forge details to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Refer to [WecOptTool documentation](https://sandialabs.github.io/WecOptTool/) fo
 WecOptTool requires Python >= 3.8. Python 3.9 & 3.10 are supported.
 It is strongly recommended you create a dedicated virtual environment (e.g., using `conda`, `venv`, etc.) before installing `wecopttool`.
 
-**Option 1** - using `Conda` (requires having [`conda-forge` added as a channel in your environment, see instructions [here](https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge)):
+**Option 1** - using `Conda` (requires having `conda-forge` added as a channel in your environment, see instructions [here](https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge)):
 
 ```bash
 conda install -c conda-forge wecopttool

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Refer to [WecOptTool documentation](https://sandialabs.github.io/WecOptTool/) fo
 WecOptTool requires Python >= 3.8. Python 3.9 & 3.10 are supported.
 It is strongly recommended you create a dedicated virtual environment (e.g., using `conda`, `venv`, etc.) before installing `wecopttool`.
 
-**Option 1** - using `Conda`:
+**Option 1** - using `Conda` (requires having [`conda-forge` added as a channel in your environment, see instructions [here](https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge)):
 
 ```bash
 conda install -c conda-forge wecopttool


### PR DESCRIPTION
## Description
The README instructions assume the user has already added conda-forge as a channel in the conda environment, which may not be clear to new users of Python and/or conda. This adds a sentence with a link to the conda-forge website specifying how to add the channel. Closes #261.

## Type of PR
- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on *your* fork, to the [main branch in WecOptTool](https://github.com/sandialabs/WecOptTool).
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Modified the documentation if applicable
- [x] Modified or added a new test
- [x] All tests pass
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)