### PR TITLE
Fix CI random failures

### DIFF
--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2376,8 +2376,7 @@ def subset_close(
         :py:func:`numpy.isclose`.
     equal_nan
         Whether to compare NaNs as equal. Passed to
-        :py:func:`numpy.isclose` and
-        :py:func:`numpy.array_equal`.
+        :py:func:`numpy.isclose`.
 
     Returns
     -------

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2376,7 +2376,8 @@ def subset_close(
         :py:func:`numpy.isclose`.
     equal_nan
         Whether to compare NaNs as equal. Passed to
-        :py:func:`numpy.isclose`.
+        :py:func:`numpy.isclose` and
+        :py:func:`numpy.array_equal`.
 
     Returns
     -------
@@ -2401,18 +2402,16 @@ def subset_close(
         raise ValueError("Elements in set_b not unique")
 
     ind = []
-    tmp_result = [False for _ in range(len(set_a))]
-    for subset_element in set_a:
-        for set_element in set_b:
-            if np.isclose(subset_element, set_element, rtol, atol, equal_nan):
-                tmp_set_ind = np.where(
-                    np.isclose(set_element, set_b , rtol, atol, equal_nan))
-                tmp_subset_ind = np.where(
-                    np.isclose(subset_element, set_a , rtol, atol,
-                               equal_nan))
-                ind.append( int(tmp_set_ind[0]) )
-                tmp_result[ int(tmp_subset_ind[0]) ] = True
-    subset = all(tmp_result)
+    for el in set_a:
+        a_in_b = np.isclose(set_b, el,
+                            rtol=rtol, atol=atol, equal_nan=equal_nan)
+        if np.sum(a_in_b) == 1:
+            ind.append(np.flatnonzero(a_in_b)[0])
+        if np.sum(a_in_b) > 1:
+            _log.warning('Multiple matching elements in subset, ' +
+                         'selecting closest match.')
+            ind.append(np.argmin(np.abs(a_in_b - el)))
+    subset = len(set_a) == len(ind)
     ind = ind if subset else []
     return subset, ind
 


### PR DESCRIPTION
## Description
Resolves #245 (and makes the call to `subset_close` around an order of magnitude faster).

## Type of PR
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on *your* fork, to the [main branch in WecOptTool](https://github.com/sandialabs/WecOptTool).
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Modified the documentation if applicable
- [x] All tests pass
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)