### PR TITLE
Allowing Python 3.11

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Community contributions are welcomed! 🎊
 
 Using `conda` this looks like:
 ```bash
-conda create -n wecopttool python=3.10
+conda create -n wecopttool python=3.11
 conda activate wecopttool
 conda install -c conda-forge capytaine wavespectra
 git clone git@github.com:<YOUR_USER_NAME>/WecOptTool.git
@@ -22,7 +22,7 @@ And using `pip`:
 ```bash
 git clone git@github.com:<YOUR_USER_NAME>/WecOptTool.git
 cd WecOptTool
-python3.10 -m venv .venv
+python3.11 -m venv .venv
 . .venv/bin/activate
 pip install -e .[dev]
 ```

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11"]  # CHANGE: Python version
+        python-version: ["3.10", "3.11"]  # CHANGE: Python version
 
     steps:
     # Checkout the WecOptTool repo

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10"]  # CHANGE: Python version
+        python-version: ["3.9", "3.10", "3.11"]  # CHANGE: Python version
 
     steps:
     # Checkout the WecOptTool repo

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -126,7 +126,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'  # CHANGE: Python version
+        python-version: '3.11'  # CHANGE: Python version
 
     - name: Install dependencies
       run: sudo apt-get install libglu1 pandoc gifsicle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Build a binary wheel and a source tarball
       run: |
@@ -47,7 +47,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install dependencies
       run: sudo apt-get install libglu1 pandoc gifsicle

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Wave Energy Converter Design Optimization Toolbox (WecOptTool) allows users 
 Refer to [WecOptTool documentation](https://sandialabs.github.io/WecOptTool/) for more information, including project overview, tutorials, theory, and API documentation.
 
 ## Getting started
-WecOptTool requires Python >= 3.8. Python 3.9 through 3.11 are supported.
+WecOptTool requires Python >= 3.8. Python 3.10 & 3.11 are supported.
 It is strongly recommended you create a dedicated virtual environment (e.g., using `conda`, `venv`, etc.) before installing `wecopttool`.
 
 **Option 1** - using `Conda` (requires having `conda-forge` added as a channel in your environment, see instructions [here](https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge)):

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Wave Energy Converter Design Optimization Toolbox (WecOptTool) allows users 
 Refer to [WecOptTool documentation](https://sandialabs.github.io/WecOptTool/) for more information, including project overview, tutorials, theory, and API documentation.
 
 ## Getting started
-WecOptTool requires Python >= 3.8. Python 3.9 & 3.10 are supported.
+WecOptTool requires Python >= 3.8. Python 3.9 through 3.11 are supported.
 It is strongly recommended you create a dedicated virtual environment (e.g., using `conda`, `venv`, etc.) before installing `wecopttool`.
 
 **Option 1** - using `Conda` (requires having `conda-forge` added as a channel in your environment, see instructions [here](https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge)):


### PR DESCRIPTION
## Description
Python 3.11 has been out for almost a year and all of our dependencies now support it, so this changes our allowed Python versions. See #270.

## Type of PR
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other: **Package management**

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on *your* fork, to the [main branch in WecOptTool](https://github.com/sandialabs/WecOptTool).
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Modified the documentation if applicable
- [x] Modified or added a new test
- [ ] All tests pass
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)