### PR TITLE
Add `netCDF4` to dependencies list.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -135,7 +135,7 @@ jobs:
       shell: bash -l {0}
       run: |
         python3 -m pip install --upgrade pip
-        pip3 install wheel coveralls netCDF4
+        pip3 install wheel coveralls
         pip3 install .[dev,geometry]
 
     - name: Build documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       shell: bash -l {0}
       run: |
         python3 -m pip install --upgrade pip
-        pip3 install wheel coveralls netCDF4
+        pip3 install wheel coveralls
         pip3 install .[dev,geometry]
 
     - name: Build documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "capytaine",
     "joblib",
     "wavespectra>=3.13",
+    "netcdf4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description
Resolves #290 and removes manual install for CI workflow (since this will be included in `pip install wecopttool` now).

## Type of PR
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on *your* fork, to the [main branch in WecOptTool](https://github.com/sandialabs/WecOptTool).
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] All tests pass
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
