### PR TITLE
Add multiple phase realizations to waves

### DIFF
--- a/examples/tutorial_1_WaveBot.ipynb
+++ b/examples/tutorial_1_WaveBot.ipynb
@@ -336,7 +336,7 @@
     "    scale_obj=scale_obj,\n",
     "    )\n",
     "\n",
-    "opt_mechanical_average_power = results.fun\n",
+    "opt_mechanical_average_power = results[0].fun\n",
     "print(f'Optimal average mechanical power: {opt_mechanical_average_power} W')"
    ]
   },
@@ -355,8 +355,8 @@
    "outputs": [],
    "source": [
     "nsubsteps = 5\n",
-    "pto_fdom, pto_tdom = pto.post_process(wec, results, waves, nsubsteps=nsubsteps)\n",
-    "wec_fdom, wec_tdom = wec.post_process(results, waves, nsubsteps=nsubsteps)"
+    "pto_fdom, pto_tdom = pto.post_process(wec, results[0], waves.sel(realization=0), nsubsteps=nsubsteps)\n",
+    "wec_fdom, wec_tdom = wec.post_process(results[0], waves.sel(realization=0), nsubsteps=nsubsteps)"
    ]
   },
   {
@@ -536,12 +536,12 @@
     "    scale_x_opt=scale_x_opt,\n",
     "    scale_obj=scale_obj,\n",
     ")\n",
-    "opt_average_power = results_2.fun\n",
+    "opt_average_power = results_2[0].fun\n",
     "print(f'Optimal average electrical power: {opt_average_power} W')\n",
     "\n",
     "# Post-process\n",
-    "wec_fdom_2, wec_tdom_2 = wec_2.post_process(results_2, waves, nsubsteps)\n",
-    "pto_fdom_2, pto_tdom_2 = pto_2.post_process(wec_2, results_2, waves, nsubsteps)"
+    "wec_fdom_2, wec_tdom_2 = wec_2.post_process(results_2[0], waves.sel(realization=0), nsubsteps)\n",
+    "pto_fdom_2, pto_tdom_2 = pto_2.post_process(wec_2, results_2[0], waves.sel(realization=0), nsubsteps)"
    ]
   },
   {
@@ -571,12 +571,12 @@
     "    scale_x_opt=scale_x_opt,\n",
     "    scale_obj=scale_obj,\n",
     ")\n",
-    "opt_average_power = results_2_nocon.fun\n",
+    "opt_average_power = results_2_nocon[0].fun\n",
     "print(f'Optimal average electrical power: {opt_average_power} W')\n",
     "wec_fdom_2_nocon, wec_tdom_2_nocon = wec_2_nocon.post_process(\n",
-    "    results_2_nocon, waves, nsubsteps)\n",
+    "    results_2_nocon[0],  waves.sel(realization=0), nsubsteps)\n",
     "pto_fdom_2_nocon, pto_tdom_2_nocon = pto_2.post_process(\n",
-    "    wec_2_nocon, results_2_nocon, waves, nsubsteps)"
+    "    wec_2_nocon, results_2_nocon[0],  waves.sel(realization=0), nsubsteps)"
    ]
   },
   {
@@ -786,7 +786,7 @@
     "        scale_x_opt=scale_x_opt,\n",
     "        scale_obj=scale_obj)\n",
     "\n",
-    "    return res.fun"
+    "    return res[0].fun"
    ]
   },
   {

--- a/examples/tutorial_1_WaveBot.ipynb
+++ b/examples/tutorial_1_WaveBot.ipynb
@@ -572,9 +572,9 @@
     "opt_average_power = results_2_nocon[0].fun\n",
     "print(f'Optimal average electrical power: {opt_average_power} W')\n",
     "wec_fdom_2_nocon, wec_tdom_2_nocon = wec_2_nocon.post_process(\n",
-    "    results_2_nocon[0],  waves.sel(realization=0), nsubsteps)\n",
+    "    results_2_nocon[0], waves.sel(realization=0), nsubsteps)\n",
     "pto_fdom_2_nocon, pto_tdom_2_nocon = pto_2.post_process(\n",
-    "    wec_2_nocon, results_2_nocon[0],  waves.sel(realization=0), nsubsteps)"
+    "    wec_2_nocon, results_2_nocon[0], waves.sel(realization=0), nsubsteps)"
    ]
   },
   {

--- a/examples/tutorial_2_AquaHarmonics.ipynb
+++ b/examples/tutorial_2_AquaHarmonics.ipynb
@@ -567,7 +567,7 @@
     "    scale_obj=scale_obj,\n",
     ")\n",
     "\n",
-    "print(f'Optimal average power: {results.fun/1e3:.2f} kW')"
+    "print(f'Optimal average power: {results[0].fun/1e3:.2f} kW')"
    ]
   },
   {
@@ -585,8 +585,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wec_fdom, wec_tdom = wec.post_process(results, waves, nsubsteps=nsubsteps)\n",
-    "pto_fdom, pto_tdom = pto.post_process(wec, results, waves, nsubsteps=nsubsteps)"
+    "wec_fdom, wec_tdom = wec.post_process(results[0], waves.sel(realization=0), nsubsteps=nsubsteps)\n",
+    "pto_fdom, pto_tdom = pto.post_process(wec, results[0], waves.sel(realization=0), nsubsteps=nsubsteps)"
    ]
   },
   {
@@ -644,7 +644,7 @@
     "    ax=ax[1], \n",
     "    label='PTO force in WEC frame',\n",
     ")\n",
-    "x_wec, x_opt = wot.decompose_state(results.x, ndof=ndof, nfreq=nfreq)\n",
+    "x_wec, x_opt = wot.decompose_state(results[0].x, ndof=ndof, nfreq=nfreq)\n",
     "ax[1].plot(\n",
     "    wec.time_nsubsteps(nsubsteps),\n",
     "    f_pto_line(wec, x_wec, x_opt, waves, nsubsteps)/1e3,\n",
@@ -797,7 +797,7 @@
     "    x_wec, x_opt = wot.decompose_state(res.x, ndof=ndof, nfreq=nfreq)\n",
     "    max_torque.append(np.max(f_pto_line(wec_mass, x_wec, x_opt, waves, nsubsteps)))\n",
     "    \n",
-    "    return res.fun"
+    "    return res[0].fun"
    ]
   },
   {

--- a/examples/tutorial_2_AquaHarmonics.ipynb
+++ b/examples/tutorial_2_AquaHarmonics.ipynb
@@ -784,7 +784,7 @@
     "        scale_x_wec=scale_x_wec,\n",
     "        scale_x_opt=scale_x_opt,\n",
     "        scale_obj=scale_obj)\n",
-    "    opt_average_power = res.fun\n",
+    "    opt_average_power = res[0].fun\n",
     "    print(\n",
     "        f'* Mass: {mass_var:.2f} kg\\n' +\n",
     "        f'* Optimal average electrical power: {opt_average_power/1e3:.2f} kW' \n",
@@ -792,8 +792,8 @@
     "\n",
     "    # wec_fdom, wec_tdom = wec_mass.post_process(res, waves, nsubsteps=nsubsteps)\n",
     "    global max_torque \n",
-    "    x_wec, x_opt = wot.decompose_state(res.x, ndof=ndof, nfreq=nfreq)\n",
-    "    max_torque.append(np.max(f_pto_line(wec_mass, x_wec, x_opt, waves, nsubsteps)))\n",
+    "    x_wec, x_opt = wot.decompose_state(res[0].x, ndof=ndof, nfreq=nfreq)\n",
+    "    max_torque.append(np.max(f_pto_line(wec_mass, x_wec, x_opt, waves.sel(realization=0), nsubsteps)))\n",
     "    \n",
     "    return res[0].fun"
    ]

--- a/examples/tutorial_3_LUPA.ipynb
+++ b/examples/tutorial_3_LUPA.ipynb
@@ -989,7 +989,7 @@
     "def irregular_wave(hs, tp):\n",
     "    fp = 1/tp\n",
     "    spectrum = lambda f: wot.waves.pierson_moskowitz_spectrum(f, fp, hs)\n",
-    "    efth = wot.waves.omnidirectional_spectrum(f1, nfreq, spectrum, \"Pierson-Moskowitz\",)\n",
+    "    efth = wot.waves.omnidirectional_spectrum(f1, nfreq, spectrum, \"Pierson-Moskowitz\")\n",
     "    return wot.waves.long_crested_wave(efth,nRealizations=5)\n",
     "\n",
     "for case, data in wave_cases.items():\n",

--- a/examples/tutorial_3_LUPA.ipynb
+++ b/examples/tutorial_3_LUPA.ipynb
@@ -989,8 +989,8 @@
     "def irregular_wave(hs, tp):\n",
     "    fp = 1/tp\n",
     "    spectrum = lambda f: wot.waves.pierson_moskowitz_spectrum(f, fp, hs)\n",
-    "    efth = wot.waves.omnidirectional_spectrum(f1, nfreq, spectrum, \"Pierson-Moskowitz\")\n",
-    "    return wot.waves.long_crested_wave(efth)\n",
+    "    efth = wot.waves.omnidirectional_spectrum(f1, nfreq, spectrum, \"Pierson-Moskowitz\",)\n",
+    "    return wot.waves.long_crested_wave(efth,nRealizations=5)\n",
     "\n",
     "for case, data in wave_cases.items():\n",
     "    waves[case] = irregular_wave(data['Hs'], data['Tp'])"
@@ -1010,21 +1010,21 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
-    "plt1 = np.abs(waves['south_max_90']).plot(\n",
+    "plt1 = np.abs(waves['south_max_90'].sel(realization=0)).plot(\n",
     "    ax=ax, color='C0', linestyle='solid', label='PW South, 90th percentile')\n",
-    "plt2 = np.abs(waves['south_max_annual']).plot(\n",
+    "plt2 = np.abs(waves['south_max_annual'].sel(realization=0)).plot(\n",
     "    ax=ax, color='C0', linestyle='dotted', label='PW South, Max Annual')\n",
-    "plt3 = np.abs(waves['south_max_occurrence']).plot(\n",
+    "plt3 = np.abs(waves['south_max_occurrence'].sel(realization=0)).plot(\n",
     "    ax=ax, color='C0', linestyle='dashed', label='PW South, Max Occurrence')\n",
-    "plt4 = np.abs(waves['south_min_10']).plot(\n",
+    "plt4 = np.abs(waves['south_min_10'].sel(realization=0)).plot(\n",
     "    ax=ax, color='C0', linestyle='dashdot', label='PW South, 10th percentile')\n",
-    "plt5 = np.abs(waves['north_max_90']).plot(\n",
+    "plt5 = np.abs(waves['north_max_90'].sel(realization=0)).plot(\n",
     "    ax=ax, color='C1', linestyle='solid', label='PW North, 90th percentile')\n",
-    "plt6 = np.abs(waves['north_max_annual']).plot(\n",
+    "plt6 = np.abs(waves['north_max_annual'].sel(realization=0)).plot(\n",
     "    ax=ax, color='C1', linestyle='dotted', label='PW North, Max Annual')\n",
-    "plt7 = np.abs(waves['north_max_occurrence']).plot(\n",
+    "plt7 = np.abs(waves['north_max_occurrence'].sel(realization=0)).plot(\n",
     "    ax=ax, color='C1', linestyle='dashed', label='PW North, Max Occurrence')\n",
-    "plt8 = np.abs(waves['north_min_10']).plot(\n",
+    "plt8 = np.abs(waves['north_min_10'].sel(realization=0)).plot(\n",
     "    ax=ax, color='C1', linestyle='dashdot', label='PW North, 10th percentile')\n",
     "\n",
     "ax.set_title('PacWave wave spectra, LWF scale', fontweight='bold')\n",
@@ -1066,8 +1066,8 @@
     "    scale_x_opt=scale_x_opt,\n",
     "    scale_obj=scale_obj,\n",
     ")\n",
-    "\n",
-    "print(f'Optimal average electrical power: {results.fun} W')"
+    "power_results = [result.fun for result in results]\n",
+    "print(f'Optimal average electrical power: {np.mean(power_results)} W')"
    ]
   },
   {
@@ -1076,7 +1076,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x_wec, x_opt = wec.decompose_state(results.x)\n",
+    "x_wec, x_opt = wec.decompose_state(results[0].x)\n",
     "print(len(x_opt))"
    ]
   },
@@ -1088,8 +1088,8 @@
    "source": [
     "# Post-process\n",
     "nsubsteps = 5\n",
-    "wec_fdom, wec_tdom = wec.post_process(results, waves['south_max_occurrence'], nsubsteps)\n",
-    "pto_fdom, pto_tdom = pto.post_process(wec, results, waves['south_max_occurrence'], nsubsteps)"
+    "wec_fdom, wec_tdom = wec.post_process(results[0], waves['south_max_occurrence'].sel(realization=0), nsubsteps)\n",
+    "pto_fdom, pto_tdom = pto.post_process(wec, results[0], waves['south_max_occurrence'].sel(realization=0), nsubsteps)"
    ]
   },
   {
@@ -1348,21 +1348,21 @@
     "        scale_x_opt=scale_x_opt,\n",
     "        scale_obj=scale_obj,\n",
     "    )\n",
-    "    print(f'Optimal average electrical power: {results.fun:.2f} W')\n",
-    "    x_wec, x_opt = wec.decompose_state(results.x)\n",
-    "    x_wec_jac , x_opt_jac = wec.decompose_state(results.jac)\n",
+    "    print(f'Optimal average electrical power: {results[0].fun:.2f} W')\n",
+    "    x_wec, x_opt = wec.decompose_state(results[0].x)\n",
+    "    x_wec_jac , x_opt_jac = wec.decompose_state(results[0].jac)\n",
     "    ds = xr.Dataset(data_vars=dict(\n",
     "        x_wec=('wec_state', x_wec),\n",
     "        x_opt=('opt_state', x_opt),\n",
     "        x_wec_jac=('wec_state', x_wec_jac),\n",
     "        x_opt_jac=('opt_state', x_opt_jac),\n",
-    "        fval=results.fun),\n",
+    "        fval=results[0].fun),\n",
     "        coords=dict(\n",
     "        wec_state=range(wec.nstate_wec),\n",
     "        opt_state=range(nstate_opt))\n",
     "    )\n",
     "    wot.write_netcdf(os.path.join(dir, 'data', f'tutorial_3_results_{x}.nc'), ds)\n",
-    "    return results.fun"
+    "    return results[0].fun"
    ]
   },
   {

--- a/examples/tutorial_3_LUPA.ipynb
+++ b/examples/tutorial_3_LUPA.ipynb
@@ -1000,7 +1000,7 @@
     "    fp = 1/tp\n",
     "    spectrum = lambda f: wot.waves.pierson_moskowitz_spectrum(f, fp, hs)\n",
     "    efth = wot.waves.omnidirectional_spectrum(f1, nfreq, spectrum, \"Pierson-Moskowitz\")\n",
-    "    return wot.waves.long_crested_wave(efth,nrealizations=5)\n",
+    "    return wot.waves.long_crested_wave(efth,nrealizations)\n",
     "\n",
     "for case, data in wave_cases.items():\n",
     "    waves[case] = irregular_wave(data['Hs'], data['Tp'])"

--- a/examples/tutorial_3_LUPA.ipynb
+++ b/examples/tutorial_3_LUPA.ipynb
@@ -956,7 +956,11 @@
     "For each site/scale they provide four wave conditions to test at the Oregon State Large Wave Flume (LWF): the maximum 90<sup>th</sup> percentile, maximum percent annual energy, maximum occurrence, and minimum 10<sup>th</sup> percentile. \n",
     "\n",
     "In this tutorial we will use the PacWave South conditions scaled to the LWF and will design for the maximum occurrence wave. \n",
-    "The wave conditions are specified in terms of significant wave height and peak period. Waves are mostly fully developed at the PacWave site, so we will use a Pierson-Moskowitz wave spectrum."
+    "The wave conditions are specified in terms of significant wave height and peak period. Waves are mostly fully developed at the PacWave site, so we will use a Pierson-Moskowitz wave spectrum. \n",
+    "\n",
+    "The irregular wave is created with multiple phase realizations. For this tutorial, the number of realizations has been overwritten to 2 to reduce the total run-time. The solver will be run once for each wave phase realization. Each of these phase realizations leads to a slightly different result for optimal average power. Thus, for irregular wave conditions, it is recommended to include multiple phase realizations. The number of phase realizations required is dependent on the desired accuracy of the result, but it is generally recommended to include enough realizations for the total simulation time to equal 20 minutes.\n",
+    "\n",
+    "$t_{total} = \\frac{nrealizations}{f1} $"
    ]
   },
   {
@@ -973,6 +977,12 @@
     "phase = 0\n",
     "wavedir = 0\n",
     "waves['regular'] = wot.waves.regular_wave(f1, nfreq, wavefreq, amplitude, phase, wavedir)\n",
+    "\n",
+    "# number of realizations to reach 20 minutes of total simulation time\n",
+    "minutes_needed = 20\n",
+    "nrealizations = minutes_needed*60*f1\n",
+    "print(f'Number of realizations for a 20 minute total simulation time: {nrealizations}')\n",
+    "nrealizations = 2 # overwrite nrealizations to reduce run-time\n",
     "\n",
     "# irregular wave cases from OSU\n",
     "wave_cases = {\n",

--- a/examples/tutorial_3_LUPA.ipynb
+++ b/examples/tutorial_3_LUPA.ipynb
@@ -990,7 +990,7 @@
     "    fp = 1/tp\n",
     "    spectrum = lambda f: wot.waves.pierson_moskowitz_spectrum(f, fp, hs)\n",
     "    efth = wot.waves.omnidirectional_spectrum(f1, nfreq, spectrum, \"Pierson-Moskowitz\")\n",
-    "    return wot.waves.long_crested_wave(efth,nRealizations=5)\n",
+    "    return wot.waves.long_crested_wave(efth,nrealizations=5)\n",
     "\n",
     "for case, data in wave_cases.items():\n",
     "    waves[case] = irregular_wave(data['Hs'], data['Tp'])"

--- a/examples/tutorial_4_Pioneer.ipynb
+++ b/examples/tutorial_4_Pioneer.ipynb
@@ -870,7 +870,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The solver is run 5 times (1 for each wave phase realization). Each of these phase realizations leads to a slightly different result for optimal average power. Thus, for irregular wave conditions, it is recommended to average the optimal average power result over multiple phase realizations. The number of phase realizations required is further discussed at the bottom of this notebook."
+    "The solver is run 5 times (1 for each wave phase realization). Each of these phase realizations leads to a slightly different result for optimal average power. Thus, for irregular wave conditions, it is recommended to average the optimal average power result over multiple phase realizations. The number of phase realizations required is dependent on the desired accuracy of the result."
    ]
   },
   {
@@ -954,13 +954,6 @@
     "    axi.grid()\n",
     "    axi.label_outer()\n",
     "    axi.autoscale(axis='x', tight=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Next, we want to demonstrate why it is recommended to test multiple phase realizations instead of testing a longer simulation time."
    ]
   }
  ],

--- a/examples/tutorial_4_Pioneer.ipynb
+++ b/examples/tutorial_4_Pioneer.ipynb
@@ -90,7 +90,7 @@
     "fp = 1/Tp\n",
     "spectrum = lambda f: wot.waves.pierson_moskowitz_spectrum(f, fp, Hs)\n",
     "efth = wot.waves.omnidirectional_spectrum(f1, nfreq, spectrum, \"Pierson-Moskowitz\")\n",
-    "waves_irregular = wot.waves.long_crested_wave(efth, nrealizations = nrealizations)"
+    "waves_irregular = wot.waves.long_crested_wave(efth, nrealizations)"
    ]
   },
   {

--- a/examples/tutorial_4_Pioneer.ipynb
+++ b/examples/tutorial_4_Pioneer.ipynb
@@ -49,7 +49,11 @@
     "\n",
     "### 1.1 Waves\n",
     "We start with the setting up the different waves we want to model, as this will inform what to select for our frequency range, which we need throughout the rest of the problem setup. \n",
-    "We will consider two waves: a regular wave and an irregular wave, both with typical characteristics of the deployment site. The regular wave is roughly at 0.35 Hz, the known pitch resonance frequency of the buoy. The irregular wave has a peak period of 5 seconds, matching that of the deployment site."
+    "We will consider two waves: a regular wave and an irregular wave, both with typical characteristics of the deployment site. The regular wave is roughly at 0.35 Hz, the known pitch resonance frequency of the buoy. The irregular wave has a peak period of 5 seconds, matching that of the deployment site. \n",
+    "\n",
+    "The irregular wave is created with multiple phase realizations. For this tutorial, the number of realizations has been overwritten to 3 to reduce the total run-time. The solver will be run once for each wave phase realization. Each of these phase realizations leads to a slightly different result for optimal average power. Thus, for irregular wave conditions, it is recommended to include multiple phase realizations and average the resultant optimal power. The number of phase realizations required is dependent on the desired accuracy of the result, but it is generally recommended to include enough realizations for the total simulation time to equal 20 minutes.\n",
+    "\n",
+    "$t_{total} = \\frac{nrealizations}{f1} $"
    ]
   },
   {
@@ -77,10 +81,16 @@
     "Hs = 1.5\n",
     "Tp = 5 \n",
     "\n",
+    "# number of realizations to reach 20 minutes of total simulation time\n",
+    "minutes_needed = 20\n",
+    "nrealizations = minutes_needed*60*f1\n",
+    "print(f'Number of realizations for a 20 minute total simulation time: {nrealizations}')\n",
+    "nrealizations = 3 # overwrite nrealizations to reduce run-time\n",
+    "\n",
     "fp = 1/Tp\n",
     "spectrum = lambda f: wot.waves.pierson_moskowitz_spectrum(f, fp, Hs)\n",
     "efth = wot.waves.omnidirectional_spectrum(f1, nfreq, spectrum, \"Pierson-Moskowitz\")\n",
-    "waves_irregular = wot.waves.long_crested_wave(efth, nrealizations = 5)"
+    "waves_irregular = wot.waves.long_crested_wave(efth, nrealizations = nrealizations)"
    ]
   },
   {
@@ -864,13 +874,6 @@
     ")\n",
     "power_results = [result.fun for result in results]\n",
     "print(f'Optimal average power: {np.mean(power_results):.2f} W')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The solver is run 5 times (1 for each wave phase realization). Each of these phase realizations leads to a slightly different result for optimal average power. Thus, for irregular wave conditions, it is recommended to average the optimal average power result over multiple phase realizations. The number of phase realizations required is dependent on the desired accuracy of the result."
    ]
   },
   {

--- a/examples/tutorial_4_Pioneer.ipynb
+++ b/examples/tutorial_4_Pioneer.ipynb
@@ -80,7 +80,7 @@
     "fp = 1/Tp\n",
     "spectrum = lambda f: wot.waves.pierson_moskowitz_spectrum(f, fp, Hs)\n",
     "efth = wot.waves.omnidirectional_spectrum(f1, nfreq, spectrum, \"Pierson-Moskowitz\")\n",
-    "waves_irregular = wot.waves.long_crested_wave(efth, nRealizations = 5)"
+    "waves_irregular = wot.waves.long_crested_wave(efth, nrealizations = 5)"
    ]
   },
   {
@@ -955,6 +955,13 @@
     "    axi.label_outer()\n",
     "    axi.autoscale(axis='x', tight=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/tutorial_4_Pioneer.ipynb
+++ b/examples/tutorial_4_Pioneer.ipynb
@@ -80,7 +80,7 @@
     "fp = 1/Tp\n",
     "spectrum = lambda f: wot.waves.pierson_moskowitz_spectrum(f, fp, Hs)\n",
     "efth = wot.waves.omnidirectional_spectrum(f1, nfreq, spectrum, \"Pierson-Moskowitz\")\n",
-    "waves_irregular = wot.waves.long_crested_wave(efth)"
+    "waves_irregular = wot.waves.long_crested_wave(efth, nRealizations = 5)"
    ]
   },
   {
@@ -100,7 +100,7 @@
     "#TODO: highlight the harmonics if wave freq and Tp with other markers+colors\n",
     "fig, ax = plt.subplots()\n",
     "np.abs(waves_regular).plot(marker = 'x', label=\"regular\")\n",
-    "np.abs(waves_irregular).plot(marker = '*', label=\"irregular\")\n",
+    "np.abs(waves_irregular.sel(realization=0)).plot(marker = '*', label=\"irregular\")\n",
     "ax.set_title('Wave elevation spectrum', fontweight='bold')\n",
     "plt.legend()"
    ]
@@ -629,7 +629,7 @@
     "    scale_x_opt=1e-2,\n",
     "    scale_obj=1e-2,\n",
     ")\n",
-    "print(f'Optimal average power: {results.fun:.2f} W')"
+    "print(f'Optimal average power: {results[0].fun:.2f} W')"
    ]
   },
   {
@@ -647,17 +647,17 @@
    "outputs": [],
    "source": [
     "nsubsteps = 5\n",
-    "wec_fdom, wec_tdom = wec.post_process(results, waves_regular, nsubsteps=nsubsteps)\n",
+    "wec_fdom, wec_tdom = wec.post_process(results[0], waves_regular.sel(realization=0), nsubsteps=nsubsteps)\n",
     "\n",
     "# Manually post-process PTO and flywheel outputs\n",
-    "x_wec, x_opt = wot.decompose_state(results.x, 1, nfreq)\n",
+    "x_wec, x_opt = wot.decompose_state(results[0].x, 1, nfreq)\n",
     "fw_pos = np.dot(wec.time_mat_nsubsteps(nsubsteps), x_opt[nstate_pto:])\n",
-    "pto_pos = rel_position(wec, x_wec, x_opt, waves_regular, nsubsteps)\n",
-    "pto_vel = rel_velocity(wec, x_wec, x_opt, waves_regular, nsubsteps)\n",
-    "pto_force = f_motor(wec, x_wec, x_opt, waves_regular, nsubsteps)\n",
+    "pto_pos = rel_position(wec, x_wec, x_opt, waves_regular.sel(realization=0), nsubsteps)\n",
+    "pto_vel = rel_velocity(wec, x_wec, x_opt, waves_regular.sel(realization=0), nsubsteps)\n",
+    "pto_force = f_motor(wec, x_wec, x_opt, waves_regular.sel(realization=0), nsubsteps)\n",
     "pto_force_fd = wec.td_to_fd(pto_force[::nsubsteps])\n",
-    "pto_mech_power = mechanical_power(wec, x_wec, x_opt, waves_regular, nsubsteps)\n",
-    "pto_elec_power = electrical_power(wec, x_wec, x_opt, waves_regular, nsubsteps)\n",
+    "pto_mech_power = mechanical_power(wec, x_wec, x_opt, waves_regular.sel(realization=0), nsubsteps)\n",
+    "pto_elec_power = electrical_power(wec, x_wec, x_opt, waves_regular.sel(realization=0), nsubsteps)\n",
     "avg_mech_power = np.mean(pto_mech_power)\n",
     "avg_elec_power = np.mean(pto_elec_power)\n"
    ]
@@ -862,7 +862,15 @@
     "    scale_x_opt=1e-2,\n",
     "    scale_obj=1e-2,\n",
     ")\n",
-    "print(f'Optimal average power: {results.fun:.2f} W')"
+    "power_results = [result.fun for result in results]\n",
+    "print(f'Optimal average power: {np.mean(power_results):.2f} W')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The solver is run 5 times (1 for each wave phase realization). Each of these phase realizations leads to a slightly different result for optimal average power. Thus, for irregular wave conditions, it is recommended to average the optimal average power result over multiple phase realizations. The number of phase realizations required is further discussed at the bottom of this notebook."
    ]
   },
   {
@@ -879,17 +887,17 @@
    "outputs": [],
    "source": [
     "nsubsteps = 5\n",
-    "wec_fdom, wec_tdom = wec.post_process(results, waves_irregular, nsubsteps=nsubsteps)\n",
+    "wec_fdom, wec_tdom = wec.post_process(results[0], waves_irregular.sel(realization=0), nsubsteps=nsubsteps)\n",
     "\n",
     "# Manually post-process PTO and flywheel outputs\n",
-    "x_wec, x_opt = wot.decompose_state(results.x, 1, nfreq)\n",
+    "x_wec, x_opt = wot.decompose_state(results[0].x, 1, nfreq)\n",
     "fw_pos = np.dot(wec.time_mat_nsubsteps(nsubsteps), x_opt[nstate_pto:])\n",
-    "pto_pos = rel_position(wec, x_wec, x_opt, waves_irregular, nsubsteps)\n",
-    "pto_vel = rel_velocity(wec, x_wec, x_opt, waves_irregular, nsubsteps)\n",
-    "pto_force = f_motor(wec, x_wec, x_opt, waves_irregular, nsubsteps)\n",
+    "pto_pos = rel_position(wec, x_wec, x_opt, waves_irregular.sel(realization=0), nsubsteps)\n",
+    "pto_vel = rel_velocity(wec, x_wec, x_opt, waves_irregular.sel(realization=0), nsubsteps)\n",
+    "pto_force = f_motor(wec, x_wec, x_opt, waves_irregular.sel(realization=0), nsubsteps)\n",
     "pto_force_fd = wec.td_to_fd(pto_force[::nsubsteps])\n",
-    "pto_mech_power = mechanical_power(wec, x_wec, x_opt, waves_irregular, nsubsteps)\n",
-    "pto_elec_power = electrical_power(wec, x_wec, x_opt, waves_irregular, nsubsteps)\n",
+    "pto_mech_power = mechanical_power(wec, x_wec, x_opt, waves_irregular.sel(realization=0), nsubsteps)\n",
+    "pto_elec_power = electrical_power(wec, x_wec, x_opt, waves_irregular.sel(realization=0), nsubsteps)\n",
     "avg_mech_power = np.mean(pto_mech_power)\n",
     "avg_elec_power = np.mean(pto_elec_power)"
    ]
@@ -949,11 +957,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "Next, we want to demonstrate why it is recommended to test multiple phase realizations instead of testing a longer simulation time."
+   ]
   }
  ],
  "metadata": {

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -192,7 +192,7 @@ def test_solve_bounds(bounds_opt, wec_from_bem, regular_wave,
                              bounds_opt=bounds_opt,
                              )
 
-    assert pytest.approx(kplim, 1e-5) == res['x'][-1]
+    assert pytest.approx(kplim, 1e-5) == res[0]['x'][-1]
 
 
 def test_same_wec_init(wec_from_bem,
@@ -208,9 +208,9 @@ def test_same_wec_init(wec_from_bem,
     x_wec_0 = np.random.randn(wec_from_bem.nstate_wec)
     np.random.seed(1)
     x_opt_0 = np.random.randn(wec_from_bem.nstate_wec)
-    bem_res = wec_from_bem.residual(x_wec_0, x_opt_0, waves)
-    fb_res = wec_from_floatingbody.residual(x_wec_0, x_opt_0, waves)
-    imp_res = wec_from_impedance.residual(x_wec_0, x_opt_0, waves)
+    bem_res = wec_from_bem.residual(x_wec_0, x_opt_0, waves.sel(realization=0))
+    fb_res = wec_from_floatingbody.residual(x_wec_0, x_opt_0, waves.sel(realization=0))
+    imp_res = wec_from_impedance.residual(x_wec_0, x_opt_0, waves.sel(realization=0))
     
     assert fb_res == approx(bem_res, rel=0.01)
     assert imp_res == approx(bem_res, rel=0.01)
@@ -261,9 +261,9 @@ class TestTheoreticalPowerLimits:
                         bounds_opt=((-1*np.infty, 0),),
                         )
 
-        power_sol = -1*res['fun']
+        power_sol = -1*res[0]['fun']
 
-        res_fd, _ = wec.post_process(res, resonant_wave,nsubsteps=1)
+        res_fd, _ = wec.post_process(res[0], resonant_wave.sel(realization=0),nsubsteps=1)
         Fex = res_fd.force.sel(
             type=['Froude_Krylov', 'diffraction']).sum('type')
         power_optimal = (np.abs(Fex)**2/8 / np.real(hydro_impedance.squeeze())
@@ -293,9 +293,9 @@ class TestTheoreticalPowerLimits:
                         bounds_opt=((-1e4, 0), (0, 2e4),)
                         )
 
-        power_sol = -1*res['fun']
+        power_sol = -1*res[0]['fun']
 
-        res_fd, _ = wec.post_process(res, regular_wave, nsubsteps=1)
+        res_fd, _ = wec.post_process(res[0], regular_wave.sel(realization=0), nsubsteps=1)
         Fex = res_fd.force.sel(
             type=['Froude_Krylov', 'diffraction']).sum('type')
         power_optimal = (np.abs(Fex)**2/8 / np.real(hydro_impedance.squeeze())
@@ -325,9 +325,9 @@ class TestTheoreticalPowerLimits:
                         scale_obj=1e-2,
                         )
 
-        power_sol = -1*res['fun']
+        power_sol = -1*res[0]['fun']
 
-        res_fd, _ = wec.post_process(res, regular_wave, nsubsteps=1)
+        res_fd, _ = wec.post_process(res[0], regular_wave.sel(realization=0), nsubsteps=1)
         Fex = res_fd.force.sel(
             type=['Froude_Krylov', 'diffraction']).sum('type')
         power_optimal = (np.abs(Fex)**2/8 / np.real(hydro_impedance.squeeze())

--- a/tests/test_waves.py
+++ b/tests/test_waves.py
@@ -59,13 +59,13 @@ class TestElevationFD:
     def elevation(self, f1, nfreq, directions):
         """Complex sea state elevation amplitude [m] indexed by
         frequency and direction."""
-        return wot.waves.elevation_fd(f1, nfreq, directions)
+        return wot.waves.elevation_fd(f1, nfreq, directions, 1)
 
     def test_coordinates(self, elevation):
         """Test that the elevation dataArray has the correct
         coordinates.
         """
-        coordinates = ['wave_direction', 'omega', 'freq']
+        coordinates = ['wave_direction', 'omega', 'freq', 'realization']
         for icoord in coordinates:
             assert icoord in elevation.coords, f'missing coordinate: {icoord}'
 
@@ -116,7 +116,7 @@ class TestRegularWave:
         """Test that the elevation dataArray has the correct
         coordinates.
         """
-        coordinates = ['wave_direction', 'omega', 'freq']
+        coordinates = ['wave_direction', 'omega', 'freq', 'realization']
         for icoord in coordinates:
             assert icoord in elevation.coords, f'missing coordinate: {icoord}'
 
@@ -180,13 +180,18 @@ class TestLongCrestedWave:
     def direction(self, ndbc_omnidirectional, ndir):
         """Wave direction."""
         return ndbc_omnidirectional.dir.values[np.random.randint(0, ndir)]
+    
+    @pytest.fixture(scope="class")
+    def nrealizations(self):
+        """Number of wave realizations."""
+        return 2
 
     @pytest.fixture(scope="class")
-    def elevation(self, ndbc_omnidirectional, direction):
+    def elevation(self, ndbc_omnidirectional, direction, nrealizations):
         """Complex sea state elevation amplitude [m] indexed by
         frequency and direction."""
         elev = wot.waves.long_crested_wave(
-            ndbc_omnidirectional.efth, direction)
+            ndbc_omnidirectional.efth, direction, None, nrealizations)
         return elev
 
     @pytest.fixture(scope="class")
@@ -223,13 +228,13 @@ class TestLongCrestedWave:
         """Test that the elevation dataArray has the correct
         coordinates.
         """
-        coordinates = ['wave_direction', 'omega', 'freq']
+        coordinates = ['wave_direction', 'omega', 'freq', 'realization']
         for icoord in coordinates:
             assert icoord in elevation.coords, f'missing coordinate: {icoord}'
 
-    def test_shape(self, elevation, nfreq, ndir):
+    def test_shape(self, elevation, nfreq, ndir, nrealizations):
         """Test that the elevation dataArray has the correct shape."""
-        assert np.squeeze(elevation.values).shape == (nfreq, )
+        assert np.squeeze(elevation.values).shape == (nfreq, nrealizations)
 
     def test_type(self, elevation):
         """Test that the elevation dataArray has the correct type."""
@@ -240,6 +245,11 @@ class TestLongCrestedWave:
         dir_out = elevation.wave_direction.values.item()
         assert np.isclose(dir_out, wot.degrees_to_radians(direction))
 
+    def test_realizations(self, elevation, direction):
+        """Test that the number of realizations is correct."""
+        realization_out = elevation.realization.values
+        assert (realization_out == [0, 1]).all()
+
     def test_spectrum(self, pm_spectrum, pm_hs):
         """Test that the constructed spectrum has the expected Hs."""
         efth = ws.SpecArray(pm_spectrum)
@@ -249,8 +259,9 @@ class TestLongCrestedWave:
         """Test that the created time series has the desired spectrum."""
         # create time-series
         direction = 0.0
-        wave = wot.waves.long_crested_wave(pm_spectrum, direction)
-        wave_ts = wot.fd_to_td(wave.values, pm_f1, pm_nfreq, False)
+        nrealizations = 1
+        wave = wot.waves.long_crested_wave(pm_spectrum, direction, nrealizations)
+        wave_ts = wot.fd_to_td(wave.sel(realization=0).values, pm_f1, pm_nfreq, False)
         # calculate the spectrum from the time-series
         t = wot.time(pm_f1, pm_nfreq)
         fs = 1/t[1]
@@ -290,7 +301,7 @@ class TestIrregularWave:
         """Test that the elevation dataArray has the correct
         coordinates.
         """
-        coordinates = ['wave_direction', 'omega', 'freq']
+        coordinates = ['wave_direction', 'omega', 'freq', 'realization']
         for icoord in coordinates:
             assert icoord in elevation.coords, f'missing coordinate: {icoord}'
 

--- a/tests/test_waves.py
+++ b/tests/test_waves.py
@@ -247,7 +247,7 @@ class TestLongCrestedWave:
     def test_realizations(self, elevation, direction):
         """Test that the number of realizations is correct."""
         realization_out = elevation.realization.values
-        assert (realization_out == [0, 1]).all()
+        assert (realization_out == [0,1]).all()
 
     def test_spectrum(self, pm_spectrum, pm_hs):
         """Test that the constructed spectrum has the expected Hs."""

--- a/tests/test_waves.py
+++ b/tests/test_waves.py
@@ -4,7 +4,6 @@
 import os
 
 import pytest
-import capytaine as cpy
 import numpy as np
 import wavespectra as ws
 from scipy import signal
@@ -180,7 +179,7 @@ class TestLongCrestedWave:
     def direction(self, ndbc_omnidirectional, ndir):
         """Wave direction."""
         return ndbc_omnidirectional.dir.values[np.random.randint(0, ndir)]
-    
+
     @pytest.fixture(scope="class")
     def nrealizations(self):
         """Number of wave realizations."""
@@ -191,7 +190,7 @@ class TestLongCrestedWave:
         """Complex sea state elevation amplitude [m] indexed by
         frequency and direction."""
         elev = wot.waves.long_crested_wave(
-            ndbc_omnidirectional.efth, direction, None, nrealizations)
+            ndbc_omnidirectional.efth, direction, nrealizations)
         return elev
 
     @pytest.fixture(scope="class")

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -716,12 +716,12 @@ class WEC:
         # objective function
         sign = -1.0 if maximize else 1.0
 
-        # constraints
-        constraints = self.constraints.copy()
-
         def obj_fun_scaled(x):
             x_wec, x_opt = self.decompose_state(x/scale)
             return obj_fun(self, x_wec, x_opt, wave)*scale_obj*sign
+
+        # constraints
+        constraints = self.constraints.copy()
 
         for i, icons in enumerate(self.constraints):
             icons_new = {"type": icons["type"]}

--- a/wecopttool/waves.py
+++ b/wecopttool/waves.py
@@ -95,7 +95,7 @@ def elevation_fd(
     freq = frequency(f1, nfreq, False)
     omega = freq*2*np.pi
 
-    dims = ('omega', 'wave_direction','realization')
+    dims = ('omega', 'wave_direction', 'realization')
     omega_attr = {'long_name': 'Radial frequency', 'units': 'rad/s'}
     freq_attr = {'long_name': 'Frequency', 'units': 'Hz'}
     dir_attr = {'long_name': 'Wave direction', 'units': 'rad'}
@@ -107,11 +107,17 @@ def elevation_fd(
 
     if amplitudes is None:
         amplitudes = np.zeros([nfreq, ndirections, nrealizations])
+    else:
+        if amplitudes.shape == (nfreq, ndirections):
+            amplitudes = np.expand_dims(amplitudes,axis=2)
+        assert amplitudes.shape == (nfreq, ndirections, 1) or \
+                amplitudes.shape == (nfreq, ndirections, nrealizations)
 
     if phases is None:
-        phases = random_phase([nfreq, ndirections, nrealizations],seed)
+        phases = random_phase([nfreq, ndirections, nrealizations], seed)
     else:
         phases = degrees_to_radians(phases, False)
+        assert phases.shape == (nfreq, ndirections, nrealizations)
 
     camplitude = amplitudes * np.exp(1j*phases)
 
@@ -190,8 +196,8 @@ def regular_wave(
 
 def long_crested_wave(
     efth: DataArray,
+    nrealizations: int,
     direction: Optional[float] = 0.0,
-    nrealizations: Optional[float] = 1,
     seed: Optional[float] = None,
 ) -> DataArray:
     """Create a complex frequency-domain wave elevation from an
@@ -210,11 +216,11 @@ def long_crested_wave(
     efth
         Omnidirection wave spectrum in units of m^2/Hz, in the format
         used by :py:class:`wavespectra.SpecArray`.
-    direction
-        Direction (in degrees) of the long-crested wave.
     nrealizations
         Number of wave phase realizations to be created for the 
         long-crested wave.
+    direction
+        Direction (in degrees) of the long-crested wave.
     seed
         Seed for random number generator. Used for reproducibility.
         Generally should not be used except for testing.
@@ -225,7 +231,6 @@ def long_crested_wave(
     values = efth.values
     values[values<0] = np.nan
     amplitudes = np.sqrt(2 * values * df)
-    amplitudes = np.expand_dims(amplitudes,axis=2)
 
     attr = {
         'Wave type': 'Long-crested irregular',
@@ -236,7 +241,7 @@ def long_crested_wave(
 
 
 def irregular_wave(efth: DataArray,
-                   nrealizations: Optional[float] = 1,
+                   nrealizations: int,
                    seed: Optional[float] = None,) -> DataArray:
     """Create a complex frequency-domain wave elevation from a spectrum.
 
@@ -270,7 +275,6 @@ def irregular_wave(efth: DataArray,
     values = efth.values
     values[values<0] = np.nan
     amplitudes = np.sqrt(2 * values * df * dd)
-    amplitudes = np.expand_dims(amplitudes,axis=2)
 
     attr = {'Wave type': 'Irregular'}
 


### PR DESCRIPTION
## Description
This PR adds a `realization` dimension to the waves DataArray (Issue #262). The number of realizations is set equal to 1 by default, but is set to 5 for tutorial 3 and 4 which have irregular waves. The `solve()` function now loops over multiple phase realizations and returns a list of the results from all optimizations.

## Type of PR
- [ ] Bug fix
- [X] New feature
- [ ] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [X] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [X] The pull request is from an issue branch (not main) on *your* fork, to the [main branch in WecOptTool](https://github.com/sandialabs/WecOptTool).
- [X] The authors have given the admins edit access
- [X] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [ ] Modified the documentation if applicable
- [ ] Modified or added a new test
- [ ] All tests pass
- [ ] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Additional details
I am still working on adding a section to one of the tutorials to demonstrate multiple phase realizations vs. a longer time window.