### PR TITLE
Add warnings when adding inertia and hydrostatic stiffness automatically

### DIFF
--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2182,11 +2182,9 @@ def run_bem(
                      'be used to auto-populate.')
         wec_im.inertia_matrix = wec_im.compute_rigid_body_inertia(rho=rho)
     if not hasattr(wec_im, 'hydrostatic_stiffness'):
-        _log.warning('FloatingBody has no hydrostatic_stiffness field. ' + 
-                     'If the FloatingBody mass is defined, it will be ' + 
-                     'used for calculating the hydrostatic stiffness here. ' + 
-                     'Otherwise, the neutral buoyancy assumption will ' + 
-                     'be used to auto-populate.')
+        _log.warning('FloatingBody has no hydrostatic_stiffness field. ' +
+                     'Capytaine will auto-populate the hydrostatic ' +
+                     'stiffness based on the provided mesh.'
         wec_im.hydrostatic_stiffness = wec_im.compute_hydrostatic_stiffness(rho=rho, g=g)
     bem_data = solver.fill_dataset(
         test_matrix, wec_im, n_jobs=njobs, **write_info)

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2184,7 +2184,7 @@ def run_bem(
     if not hasattr(wec_im, 'hydrostatic_stiffness'):
         _log.warning('FloatingBody has no hydrostatic_stiffness field. ' +
                      'Capytaine will auto-populate the hydrostatic ' +
-                     'stiffness based on the provided mesh.'
+                     'stiffness based on the provided mesh.')
         wec_im.hydrostatic_stiffness = wec_im.compute_hydrostatic_stiffness(rho=rho, g=g)
     bem_data = solver.fill_dataset(
         test_matrix, wec_im, n_jobs=njobs, **write_info)

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2175,8 +2175,18 @@ def run_bem(
     wec_im = fb.copy(name=f"{fb.name}_immersed").keep_immersed_part()
     wec_im = set_fb_centers(wec_im, rho=rho)
     if not hasattr(wec_im, 'inertia_matrix'):
+        _log.warning('FloatingBody has no inertia_matrix field. ' + 
+                     'If the FloatingBody mass is defined, it will be ' + 
+                     'used for calculating the inertia matrix here. ' + 
+                     'Otherwise, the neutral buoyancy assumption will ' + 
+                     'be used to auto-populate.')
         wec_im.inertia_matrix = wec_im.compute_rigid_body_inertia(rho=rho)
     if not hasattr(wec_im, 'hydrostatic_stiffness'):
+        _log.warning('FloatingBody has no hydrostatic_stiffness field. ' + 
+                     'If the FloatingBody mass is defined, it will be ' + 
+                     'used for calculating the hydrostatic stiffness here. ' + 
+                     'Otherwise, the neutral buoyancy assumption will ' + 
+                     'be used to auto-populate.')
         wec_im.hydrostatic_stiffness = wec_im.compute_hydrostatic_stiffness(rho=rho, g=g)
     bem_data = solver.fill_dataset(
         test_matrix, wec_im, n_jobs=njobs, **write_info)


### PR DESCRIPTION
## Description
This PR resolves #345 by adding warning messages when we call `run_bem` and add the inertia matrix and hydrostatic stiffness automatically. Capytaine uses the mass of the FloatingBody if defined. If not, itassumes neutral buoyancy for calculating the [inertia matrix and hydrostatic stiffness](https://capytaine.github.io/stable/user_manual/hydrostatics.html).
