### PR TITLE
Update release instructions for generating release notes

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -11,7 +11,7 @@ In the GitHub repository, click on *Releases*, click on *Draft new release*.
 
 * Title the release with the [version number](https://semver.org/) preceded by a `v`, e.g., `v1.0.0`. Nothing else should go in the title.
 * Tag the release using the same name as the *Title*.
-* Click on *Generate release notes*. This adds the PR messages and contributors. Ideally nothing more is needed, but might require minor editing/formatting.
+* <u>Temporarily</u> change the *Target* branch to `dev`, then click on *Generate release notes*. This adds the PR messages and contributors. Ideally nothing more is needed, but might require minor editing/formatting. <u>**Be sure to change the *Target* back to `main` after the release notes are generated!!!**</u>
 * Select the *Create a discussion* checkmark and mark as *Announcement*.
 
 This will trigger the PyPI, Conda, and GH-Pages build and deploy.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -11,7 +11,7 @@ In the GitHub repository, click on *Releases*, click on *Draft new release*.
 
 * Title the release with the [version number](https://semver.org/) preceded by a `v`, e.g., `v1.0.0`. Nothing else should go in the title.
 * Tag the release using the same name as the *Title*.
-* <u>Temporarily</u> change the *Target* branch to `dev`, then click on *Generate release notes*. This adds the PR messages and contributors. Ideally nothing more is needed, but might require minor editing/formatting. <u>**Be sure to change the *Target* back to `main` after the release notes are generated!!!**</u>
+* <ins>Temporarily</ins> change the *Target* branch to `dev`, then click on *Generate release notes*. This adds the PR messages and contributors. Ideally nothing more is needed, but might require minor editing/formatting. <ins>**Be sure to change the *Target* back to `main` after the release notes are generated!!!**</ins>
 * Select the *Create a discussion* checkmark and mark as *Announcement*.
 
 This will trigger the PyPI, Conda, and GH-Pages build and deploy.


### PR DESCRIPTION
## Description
With the new workflow to target PRs to the `dev` branch instead of `main`, and only pushing to `main` on a new release, this makes GitHub's [automatic release notes generator](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) much less informative, since it will only include the single `dev` -> `main` PR. The workaround for this is to temporarily change the target branch for the release to `dev`, generate the release notes, then change the target branch back to `main` (yes, it's a bit clunky, but it only takes an extra few seconds and is by far the easiest solution for this). This PR updates RELEASING.md to describe this workaround so we can reference it for future releases.

## Type of PR
- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on *your* fork, to the [dev branch in WecOptTool](https://github.com/sandialabs/WecOptTool/tree/dev).
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Modified the documentation if applicable
- [x] All tests pass