### PR TITLE
Add debug option for building documentation locally

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -139,4 +139,4 @@ jobs:
       shell: bash -l {0}
       run: |
         git fetch --tags
-        python3 docs/build_docs.py
+        python3 docs/build_docs.py --build production

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -138,7 +138,7 @@ jobs:
       shell: bash -l {0}
       run: |
         git fetch --tags
-        python3 docs/build_docs.py
+        python3 docs/build_docs.py --build production
 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       shell: bash -l {0}
       run: |
         git fetch --tags
-        python3 docs/build_docs.py
+        python3 docs/build_docs.py --build production
 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -3,6 +3,7 @@ import subprocess
 import shutil
 import re
 import yaml
+import argparse 
 
 from sphinx.application import Sphinx
 
@@ -17,6 +18,8 @@ linkcheck_dir = os.path.join(build_dir, 'linkcheck')
 html_dir = os.path.join(build_dir, 'html')
 doctree_dir = os.path.join(build_dir, 'doctrees')
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--build', '-b', nargs=1, type=str, default='debug')
 
 def linkcheck():
     app = Sphinx(source_dir,
@@ -51,36 +54,50 @@ def cleanup():
         f.write(data2)
 
 
-def build_doc(version, tag, home_branch):
-    os.environ['current_version'] = version
-    subprocess.run(f'git checkout {tag}', shell=True)
-    subprocess.run(
-        f"git checkout {home_branch} -- {os.path.join(source_dir, 'conf.py')}", shell=True)
-    subprocess.run(
-        f"git checkout {home_branch} -- {os.path.join(docs_dir, 'versions.yaml')}", shell=True)
-    subprocess.run(
-        f"git checkout {home_branch} -- {os.path.join(source_dir, '_templates/versions.html')}", shell=True)
+def build_doc(version, tag, home_branch, build):
+    if build != 'debug':
+        os.environ['current_version'] = version
+        subprocess.run(f'git checkout {tag}', shell=True)
+        subprocess.run(
+            f"git checkout {home_branch} -- {os.path.join(source_dir, 'conf.py')}",
+            shell=True)
+        subprocess.run(
+            f"git checkout {home_branch} -- {os.path.join(docs_dir, 'versions.yaml')}",
+            shell=True)
+        subprocess.run(
+            f"git checkout {home_branch} -- {os.path.join(source_dir, '_templates/versions.html')}",
+            shell=True)
     source.make_theory_animations
     linkcheck()
     html()
     cleanup()
-    subprocess.run(
-        f"git checkout {home_branch}", shell=True)
+    if build != 'debug':
+        subprocess.run(
+            f"git checkout {home_branch}", shell=True)
 
 
-if __name__ == '__main__':
-    home_name = 'latest'
-    with open(os.path.join(docs_dir, 'versions.yaml'), 'r') as v_file:
-        versions = yaml.safe_load(v_file)
-    home_branch = versions[home_name]
-    build_doc(home_name, home_branch, home_branch)
+def move_pages():
     print(f"Moving HTML pages to {os.path.join(docs_dir, 'pages')}...")
     shutil.copytree(html_dir, os.path.join(docs_dir, 'pages'))
     print('Done.')
-    for name, tag in versions.items():
-        if name != home_name:
-            build_doc(name, tag, home_branch)
-            print(f"Moving HTML pages to {os.path.join(docs_dir, 'pages', name)}...")
-            shutil.copytree(html_dir, os.path.join(docs_dir, 'pages', name))
-            print('Done.')
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    build = args.build
+    if build == 'debug':
+        print(f'Building docs in current branch...')
+        build_doc('latest', '', '', build)
+        move_pages()
+    else:
+        home_name = 'latest'
+        with open(os.path.join(docs_dir, 'versions.yaml'), 'r') as v_file:
+            versions = yaml.safe_load(v_file)
+        home_branch = versions[home_name]
+        build_doc(home_name, home_branch, home_branch, build)
+        move_pages()
+        for name, tag in versions.items():
+            if name != home_name:
+                build_doc(name, tag, home_branch)
+                move_pages()
     shutil.rmtree(html_dir)

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -19,7 +19,9 @@ html_dir = os.path.join(build_dir, 'html')
 doctree_dir = os.path.join(build_dir, 'doctrees')
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--build', '-b', nargs=1, type=str, default='debug')
+parser.add_argument('-b', '--build', nargs=1, type=str,
+                    choices=['debug', 'production'],
+                    default='debug')
 
 def linkcheck():
     app = Sphinx(source_dir,


### PR DESCRIPTION
## Description
Resolves #373. The default build option when calling `docs/build_docs.py` is `debug`, which only builds the documentation for the git branch you are currently on. Calling `python docs/build_docs.py --build production` will create multiple versions of the documentation as per #347, and is called in the GitHub CI workflows

## Type of PR
- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on *your* fork, to the [dev branch in WecOptTool](https://github.com/sandialabs/WecOptTool/tree/dev).
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Modified the documentation if applicable
- [x] Modified or added a new test
- [ ] All tests pass
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)