### PR TITLE
Fix pioneer tutorial bug on dev

### DIFF
--- a/examples/tutorial_4_Pioneer.ipynb
+++ b/examples/tutorial_4_Pioneer.ipynb
@@ -306,6 +306,7 @@
     "datafile = 'data/pioneer_empirical_data.nc'\n",
     "empirical_data = xr.load_dataset(datafile)\n",
     "\n",
+    "omega_data = empirical_data.omega\n",
     "exc_coeff_data = empirical_data.exc_coeff_data_real + 1j*empirical_data.exc_coeff_data_imag\n",
     "Zi_data = empirical_data.Zi_data_real + 1j*empirical_data.Zi_data_imag\n",
     "Zi_stiffness = empirical_data.Zi_stiffness\n",


### PR DESCRIPTION
## Description
`omega_data` was being used to plot before the variable is defined. This was an issue from PR #362 but not detected immediately. This bug is only on dev.

## Type of PR
- [X] Bug fix

## Checklist for PR
- [X] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [X] The pull request is from an issue branch (not main) on *your* fork, to the [dev branch in WecOptTool](https://github.com/sandialabs/WecOptTool/tree/dev).
- [X] The authors have given the admins edit access
- [X] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [ ] Modified the documentation if applicable
- [ ] Modified or added a new test
- [ ] All tests pass
- [ ] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Additional details
N/A