### PR TITLE
Add PTO kinematics comment regarding gear ratio

### DIFF
--- a/examples/tutorial_1_WaveBot.ipynb
+++ b/examples/tutorial_1_WaveBot.ipynb
@@ -308,6 +308,7 @@
     "\n",
     "* The kinematics matrix, which converts from the WEC degrees of freedom to the PTO degrees of freedom.\n",
     "In this case, the PTO extracts power directly from the heaving motion of the WEC, so the kinematics matrix is simply a $1 \\times 1$ identity matrix.\n",
+    "  * Note that the PTO kinematics does not account for any gear ratio (instead included in PTO impedance matrix), so the resultant PTO kinematics will not reflect gearing.\n",
     "* The definition of the PTO controller.\n",
     "The `wecopttool.pto` submodule includes P, PI, and PID controller functions that can be provided to the `PTO` class and return the PTO force.\n",
     "However, we will be using an unstructured controller in this case, which is the default when `controller=None`.\n",

--- a/examples/tutorial_4_Pioneer.ipynb
+++ b/examples/tutorial_4_Pioneer.ipynb
@@ -306,6 +306,7 @@
     "datafile = 'data/pioneer_empirical_data.nc'\n",
     "empirical_data = xr.load_dataset(datafile)\n",
     "\n",
+    "omega_data = empirical_data.omega\n",
     "exc_coeff_data = empirical_data.exc_coeff_data_real + 1j*empirical_data.exc_coeff_data_imag\n",
     "Zi_data = empirical_data.Zi_data_real + 1j*empirical_data.Zi_data_imag\n",
     "Zi_stiffness = empirical_data.Zi_stiffness\n",


### PR DESCRIPTION
## Description
Added comment to specify that PTO kinematics do not include gear ratio to resolve Issue #371 

## Type of PR
- [ ] Bug fix
- [ ] New feature
- [X] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [X] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [X] The pull request is from an issue branch (not main) on *your* fork, to the [dev branch in WecOptTool](https://github.com/sandialabs/WecOptTool/tree/dev).
- [X] The authors have given the admins edit access
- [X] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [X] Modified the documentation if applicable
- [ ] Modified or added a new test
- [ ] All tests pass
- [X] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Additional details
N/A
