### PR TITLE
Use Miniforge distribution in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,10 +30,10 @@ jobs:
     #   - the content of pyproject.toml changes
     #   - you manually change the value of the CACHE_NUMBER below
     # Else the existing cache is used.
-    - name: Setup Mambaforge
+    - name: Setup Miniforge
       uses: conda-incubator/setup-miniconda@v2
       with:
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge
           miniforge-version: latest
           activate-environment: test-env
           use-mamba: true
@@ -45,8 +45,6 @@ jobs:
       shell: bash
 
     # create a conda yaml file
-    # for some reason Windows installs capytaine 1.4 instead of latest.
-    # CHANGE: Capytaine version
     - name: Create environment.yml file
       run: |
         echo "name: test-env" >> environment.yml;

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
     #   - you manually change the value of the CACHE_NUMBER below
     # Else the existing cache is used.
     - name: Setup Miniforge
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
           miniforge-variant: Miniforge
           miniforge-version: latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,7 +30,7 @@ jobs:
     #   - the content of pyproject.toml changes
     #   - you manually change the value of the CACHE_NUMBER below
     # Else the existing cache is used.
-    - name: Setup Mambaforge
+    - name: Setup Miniforge
       uses: conda-incubator/setup-miniconda@v2
       with:
           miniforge-variant: Miniforge

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2
       with:
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge
           miniforge-version: latest
           activate-environment: test-env
           use-mamba: true
@@ -45,8 +45,6 @@ jobs:
       shell: bash
 
     # create a conda yaml file
-    # for some reason Windows installs capytaine 1.4 instead of latest.
-    # CHANGE: Capytaine version
     - name: Create environment.yml file
       run: |
         echo "name: test-env" >> environment.yml;

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,7 +31,7 @@ jobs:
     #   - you manually change the value of the CACHE_NUMBER below
     # Else the existing cache is used.
     - name: Setup Miniforge
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
           miniforge-variant: Miniforge
           miniforge-version: latest


### PR DESCRIPTION
## Description
The CI has previously used the Mambaforge distribution for its testing environment, [which has now been sunsetted as of the beginning of 2025](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/). This updates the CI to use the Miniforge distribution instead, which should operate the same for our purposes. This should fix all the CI failures that PRs have been seeing recently.

## Type of PR
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other: **CI/CD**

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on *your* fork, to the [dev branch in WecOptTool](https://github.com/sandialabs/WecOptTool/tree/dev).
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Modified the documentation if applicable
- [x] Modified or added a new test
- [ ] All tests pass
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)