### PR TITLE
Revert to Python 3.12

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Using `conda` this looks like:
 ```bash
 conda create -n wecopttool
 conda activate wecopttool
-conda install -c conda-forge python=3.13 capytaine wavespectra
+conda install -c conda-forge python=3.12 capytaine wavespectra
 git clone git@github.com:<YOUR_USER_NAME>/WecOptTool.git
 cd WecOptTool
 pip install -e .[dev]
@@ -22,7 +22,7 @@ And using `pip`:
 ```bash
 git clone git@github.com:<YOUR_USER_NAME>/WecOptTool.git
 cd WecOptTool
-python3.13 -m venv .venv
+python3.12 -m venv .venv
 . .venv/bin/activate
 pip install -e .[dev]
 ```

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.12", "3.13.0"]  # CHANGE: Python version
+        python-version: ["3.11", "3.12"]  # CHANGE: Python version
 
     steps:
     # Checkout the WecOptTool repo
@@ -121,7 +121,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.13'  # CHANGE: Python version
+        python-version: '3.12'  # CHANGE: Python version
 
     - name: Install dependencies
       run: sudo apt-get install libglu1 pandoc gifsicle

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.12", "3.13"]  # CHANGE: Python version
+        python-version: ["3.12", "3.13.0"]  # CHANGE: Python version
 
     steps:
     # Checkout the WecOptTool repo

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,7 +67,7 @@ jobs:
     # if cache key has changed, create new cache
     - name: Update environment
       run: mamba env update -n test-env -f environment.yml
-      if: steps.cache.outputs.cache-hit != 'true'
+      # if: steps.cache.outputs.cache-hit != 'true'
     # <<< Cache the conda environment
 
     # install libglu on ubuntu.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,7 +67,7 @@ jobs:
     # if cache key has changed, create new cache
     - name: Update environment
       run: mamba env update -n test-env -f environment.yml
-      # if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
     # <<< Cache the conda environment
 
     # install libglu on ubuntu.

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.12", "3.13"]  # CHANGE: Python version
+        python-version: ["3.12", "3.13.0"]  # CHANGE: Python version
 
     steps:
     # Checkout the WecOptTool repo

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.12", "3.13.0"]  # CHANGE: Python version
+        python-version: ["3.11", "3.12"]  # CHANGE: Python version
 
     steps:
     # Checkout the WecOptTool repo
@@ -120,7 +120,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.13' # CHANGE: Python version
+        python-version: '3.12' # CHANGE: Python version
 
     - name: Install dependencies
       run: sudo apt-get install libglu1 pandoc gifsicle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.13' # CHANGE: Python version
+        python-version: '3.12' # CHANGE: Python version
 
     - name: Build a binary wheel and a source tarball
       run: |
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.13' # CHANGE: Python version
+        python-version: '3.12' # CHANGE: Python version
 
     - name: Install dependencies
       run: sudo apt-get install libglu1 pandoc gifsicle

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Refer to [WecOptTool documentation](https://sandialabs.github.io/WecOptTool/) fo
 ## Getting started
 **If you are brand new to Python and/or want detailed installation instructions, [click here](https://github.com/sandialabs/WecOptTool/blob/main/INSTALLATION.md).**
 
-WecOptTool requires Python >= 3.8. Python 3.12 & 3.13 are supported.
+WecOptTool requires Python >= 3.8. Python 3.11 & 3.12 are supported.
 It is strongly recommended you create a dedicated virtual environment (e.g., using [`conda`](https://www.anaconda.com/), [`mamba`](https://mamba.readthedocs.io/en/latest/), `venv`, etc.) before installing WecOptTool.
 
 From your dedicated environment, you can install WecOptTool via `conda`, `pip`, or `mamba`:


### PR DESCRIPTION
After merging #390, the "update environment" step of the tests ran and found an error. Wavespectra is not yet compatible with 3.13. To fix this, this PR reverts back to python 3.12 (still an update from previous version (3.11)).