### PR TITLE
Use dev branch source when building dev documentation (main)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -130,7 +130,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         pip3 install wheel coveralls
-        pip3 install .[dev,geometry]
+        pip3 install -e .[dev,geometry]
 
     - name: Build documentation
       shell: bash -l {0}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -130,14 +130,17 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         pip3 install wheel coveralls
-        pip3 install .[dev,geometry]
+        pip3 install -e .[dev,geometry]
+
+    - name: Check Sphinx version
+      run: |
+        python -m pip show sphinx
 
     - name: Build documentation
       shell: bash -l {0}
       run: |
         git fetch --tags
         python3 docs/build_docs.py
-
 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -132,10 +132,6 @@ jobs:
         pip3 install wheel coveralls
         pip3 install -e .[dev,geometry]
 
-    - name: Check Sphinx version
-      run: |
-        python -m pip show sphinx
-
     - name: Build documentation
       shell: bash -l {0}
       run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -132,6 +132,10 @@ jobs:
         pip3 install wheel coveralls
         pip3 install -e .[dev,geometry]
 
+    - name: Check Sphinx version
+      run: |
+        python -m pip show sphinx
+
     - name: Build documentation
       shell: bash -l {0}
       run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -130,17 +130,14 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         pip3 install wheel coveralls
-        pip3 install -e .[dev,geometry]
-
-    - name: Check Sphinx version
-      run: |
-        python -m pip show sphinx
+        pip3 install .[dev,geometry]
 
     - name: Build documentation
       shell: bash -l {0}
       run: |
         git fetch --tags
         python3 docs/build_docs.py
+
 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "sphinx",
+    "sphinx<8.2.0",
     "sphinxcontrib-bibtex",
     "sphinx_rtd_theme",
     "jupyter",


### PR DESCRIPTION
## Description
This PR makes sure WecOptTool is using the dev branch source code when building documentation. This PR also specifies sphinx<8.2 to avoid errors with new sphinx version. This should fix the failing tests.

## Type of PR
- [X] Bug fix
