### PR TITLE
Use dev branch source when building dev documentation (dev)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -130,7 +130,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         pip3 install wheel coveralls
-        pip3 install .[dev,geometry]
+        pip3 install -e .[dev,geometry]
 
     - name: Build documentation
       shell: bash -l {0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "sphinx",
+    "sphinx<8.2.0",
     "sphinxcontrib-bibtex",
     "sphinx_rtd_theme",
     "jupyter",


### PR DESCRIPTION
Same as #395 but for dev branch.

## Description
This PR makes sure WecOptTool is using the dev branch source code when building documentation. This PR also specifies sphinx<8.2 to avoid errors with new sphinx version. This should fix the failing tests.

## Type of PR
- [X] Bug fix
