### PR TITLE
Documentation example to simulate WEC dynamics without optimization

### DIFF
--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -20,6 +20,63 @@ The fourth tutorial uses the `Pioneer WEC` model, which includes a unique pitch 
 
     - :doc:`_examples/tutorial_4_Pioneer`: Example with custom PTO physics and modeling both hydrodynamic and non-hydrodynamic degrees of freedom.
 
+Simulating WEC Dynamics without optimization
+--------------------------------------------
+
+There may be situations where it is useful to see the dynamics of the WEC subject to certain constraints without performing optimization on the device.
+This can be done by setting ``nstate_opt=0`` and using an objective function that does not depend on ``x_wec``.
+The easiest way to do this is to set an objective function that always equals zero. 
+Constraints and additional forces can also be added, but they must be independent of ``x_opt`` since there are no constrol states.
+The additional forces should also be defined at all nonzero states (i.e. have length ``nfreq * 2``).
+
+Example:
+
+.. code-block:: python
+
+   waves = ... # unchanged from normal
+   bem_data = ... # unchanged from normal
+
+   # define additional force
+   # (must be independent of x_opt and of length nfreq * 2)
+   def forcing_func(wec, x_wec, x_opt, waves):
+       frc = 50
+       return np.ones((nfreq*2, 1)) * frc
+    f_add = {'Additional force': forcing_func}
+
+   # define constraint
+   # (must be independent of x_opt)
+   f_max = 750.
+   def force_constraint(wec, x_wec, x_opt, waves):
+       return f_max
+   ineq_cons = {'type': 'ineq',
+                'fun': force_constraint,
+                }
+   constraints = [ineq_cons]
+
+   # define WEC object
+   wec = wot.WEC.from_bem(
+        bem_data,
+        constraints=constraints,
+        friction=None,
+        f_add=f_add)
+
+   # create dummy objective function
+   obj_fun = lambda wec, x_wec, x_opt, waves : 0
+   nstate_opt = 0
+
+   # solve problem (should solve on first iteration)
+   results = wec.solve(
+       waves=waves,
+       obj_fun=obj_fun, 
+       nstate_opt=nstate_opt
+       )
+       
+   # post process
+   nsubsteps = 5
+   wec_fdom, wec_tdom = wec.post_process(wec, results, waves, nsubsteps=nsubsteps)
+   wec_tdom[0]['pos'].plot()
+
+
 .. _GitHub repository: https://github.com/sandialabs/WecOptTool/tree/main/examples
 .. _WaveBot: https://doi.org/10.3390/en10040472
 .. _AquaHarmonics: https://aquaharmonics.com/technology/

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -25,16 +25,17 @@ Simulating WEC Dynamics without optimization
 
 There may be situations where it is useful to see the dynamics of the WEC subject to certain constraints without performing optimization on the device.
 This can be done by setting ``nstate_opt=0`` and using an objective function that does not depend on ``x_wec``.
+
 The easiest way to do this is to set an objective function that always equals zero. 
 Constraints and additional forces can also be added, but they must be independent of ``x_opt`` since there are no constrol states.
-The additional forces should also be defined at all nonzero states (i.e. have length ``nfreq * 2``).
+The additional forces should also be defined at all nonzero states (i.e. returns length ``nfreq * 2``).
 
 Example:
 
 .. code-block:: python
 
-   waves = ... # unchanged from normal
-   bem_data = ... # unchanged from normal
+   waves = ... # define as you normally would
+   bem_data = ... # define as you normally would
 
    # define additional force
    # (must be independent of x_opt and of length nfreq * 2)


### PR DESCRIPTION
## Description
Closes #325 (specifically addresses [this comment](https://github.com/sandialabs/WecOptTool/issues/325#issuecomment-2034872255)) by adding a section to the documentation with a basic working example. I put this on the Tutorials documentation page for now, but I'm not sure if this is the best location, so I'm open to suggestions!

Here's a screenshot of what the new documentation section looks like when built:
![image](https://github.com/user-attachments/assets/53b7270f-8ae6-4988-8457-5dd21e32ad90)

## Type of PR
- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on *your* fork, to the [dev branch in WecOptTool](https://github.com/sandialabs/WecOptTool/tree/dev).
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Modified the documentation if applicable
- [x] Modified or added a new test
- [x] All tests pass
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)