### PR TITLE
Sphinx build argument bug fix

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -93,7 +93,7 @@ def move_pages(dest_dir=None):
 
 if __name__ == '__main__':
     args = parser.parse_args()
-    build = args.build
+    build = args.build[0]
     if build == 'debug':
         print(f'Building docs in current branch...')
         build_doc('latest', '', '', build)


### PR DESCRIPTION
## Description
I discovered a bug in `docs/build_docs.py` where the "build" specification returns as a list of length 1 instead of a string, so the if statements added in #374 to enable a debug or production build were not working as intended. Specifically, the `if build != 'debug'` options were always triggered even if the user specifies `python docs/build_docs.py --build debug` since the `build` variable would be `['debug']`, not `'debug'`. This PR fixes this bug so the different build options are handled correctly.

## Type of PR
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on *your* fork, to the [dev branch in WecOptTool](https://github.com/sandialabs/WecOptTool/tree/dev).
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Modified the documentation if applicable
- [x] Modified or added a new test
- [x] All tests pass
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)