### PR TITLE
Remove sphinx version requirement

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -131,7 +131,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         pip3 install wheel coveralls
-        pip3 install .[dev,geometry]
+        pip3 install -e .[dev,geometry]
 
     - name: Build documentation
       shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         pip3 install wheel coveralls
-        pip3 install .[dev,geometry]
+        pip3 install -e .[dev,geometry]
 
     - name: Build documentation
       shell: bash -l {0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "sphinx<8.2.0",
+    "sphinx",
     "sphinxcontrib-bibtex",
     "sphinx_rtd_theme",
     "jupyter",


### PR DESCRIPTION
## Description
The bug that was causing sphinx v8.2.0 to fail (identified by #396 and noted in #397) seems to be resolved in releases 8.2.1 and/or 8.2.2 from the [Sphinx changelog](https://www.sphinx-doc.org/en/master/changes/8.2.html).

Also updates the pr.yml and release.yml to use current dev branch source for building documentation.