### PR TITLE
Hydrostatics warning messages

### DIFF
--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2177,7 +2177,7 @@ def run_bem(
                       'wavelength': False,
                       'wavenumber': False,
                      }
-    wec_im = fb.copy(name=f"{fb.name}_immersed").keep_immersed_part()
+    wec_im = fb.copy(name=fb.name)
     wec_im = set_fb_centers(wec_im, rho=rho)
     if not hasattr(wec_im, 'inertia_matrix'):
         _log.warning('FloatingBody has no inertia_matrix field. ' + 
@@ -2186,6 +2186,7 @@ def run_bem(
                      'Otherwise, the neutral buoyancy assumption will ' + 
                      'be used to auto-populate.')
         wec_im.inertia_matrix = wec_im.compute_rigid_body_inertia(rho=rho)
+    wec_im = fb.copy(name=f"{fb.name}_immersed").keep_immersed_part()
     if not hasattr(wec_im, 'hydrostatic_stiffness'):
         _log.warning('FloatingBody has no hydrostatic_stiffness field. ' +
                      'Capytaine will auto-populate the hydrostatic ' +

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2177,16 +2177,17 @@ def run_bem(
                       'wavelength': False,
                       'wavenumber': False,
                      }
-    wec_im = fb.copy(name=fb.name)
+    wec_im = fb.copy(name=f"{fb.name}_immersed").keep_immersed_part()
     wec_im = set_fb_centers(wec_im, rho=rho)
     if not hasattr(wec_im, 'inertia_matrix'):
         _log.warning('FloatingBody has no inertia_matrix field. ' + 
                      'If the FloatingBody mass is defined, it will be ' + 
                      'used for calculating the inertia matrix here. ' + 
                      'Otherwise, the neutral buoyancy assumption will ' + 
-                     'be used to auto-populate.')
+                     'be used to auto-populate (inertial properties ' +
+                     'based only on the immersed part). We recommend ' +
+                     'inputting the correct inertial properties.')
         wec_im.inertia_matrix = wec_im.compute_rigid_body_inertia(rho=rho)
-    wec_im = wec_im.copy(name=f"{wec_im.name}_immersed").keep_immersed_part()
     if not hasattr(wec_im, 'hydrostatic_stiffness'):
         _log.warning('FloatingBody has no hydrostatic_stiffness field. ' +
                      'Capytaine will auto-populate the hydrostatic ' +

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2587,7 +2587,10 @@ def set_fb_centers(
                 def_val = fb.center_of_mass
                 log_str = (
                     "Using the center of gravity (COG) as the rotation center " +
-                    "for hydrostatics.")
+                    "for hydrostatics. Note that the hydrostatics do not use the " +
+                    "axes defined by the Floating Body degrees of freedom, and the " + 
+                    "rotation center should be set manually when using Capytaine to " + 
+                    "calculate hydrostatics about an axis other than the COG.")
             setattr(fb, property, def_val)
             _log.warning(log_str)
         elif getattr(fb, property) is not None:

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2186,7 +2186,7 @@ def run_bem(
                      'Otherwise, the neutral buoyancy assumption will ' + 
                      'be used to auto-populate.')
         wec_im.inertia_matrix = wec_im.compute_rigid_body_inertia(rho=rho)
-    wec_im = fb.copy(name=f"{fb.name}_immersed").keep_immersed_part()
+    wec_im = wec_im.copy(name=f"{wec_im.name}_immersed").keep_immersed_part()
     if not hasattr(wec_im, 'hydrostatic_stiffness'):
         _log.warning('FloatingBody has no hydrostatic_stiffness field. ' +
                      'Capytaine will auto-populate the hydrostatic ' +


### PR DESCRIPTION
## Description
This PR resolves issue #399 and #398 by adding to the warning messages:
- Inertia matrix uses the immersed part and should be specified manually for more than just equilibrium heave.
- Rotation center is assumed as COG even when the rotation dofs have axes separate from the COG and should be specified manually in these cases.