### PR TITLE
Inertia matrix fix

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -93,7 +93,7 @@ def move_pages(dest_dir=None):
 
 if __name__ == '__main__':
     args = parser.parse_args()
-    build = args.build
+    build = args.build[0]
     if build == 'debug':
         print(f'Building docs in current branch...')
         build_doc('latest', '', '', build)

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2182,17 +2182,15 @@ def run_bem(
     if not hasattr(wec_im, 'inertia_matrix'):
         if wec_im.mass is None:
             wec_im.mass = rho*wec_im.copy().keep_immersed_part().volume
+            _log.warning('FloatingBody has no inertia_matrix or mass ' +
+                     'field. The mass will be calculated based on a ' +
+                     'neutral buoyancy assumption. The inertia matrix ' +
+                     'will be calculated assuming a solid and constant ' +
+                     'density body.')
+        else:
             _log.warning('FloatingBody has no inertia_matrix field. ' + 
                      'The FloatingBody mass is defined and will be ' +
-                     'used to determine material density and for ' +
-                     'calculating the inertia matrix.)')
-        else:
-            _log.warning('FloatingBody has no inertia_matrix or mass ' +
-                     'field. The neutral buoyancy assumption will be ' +
-                     'used to auto-populate. The mass will be based on ' +
-                     'the immersed part and the rotation inertia ' +
-                     'calculation uses the full mesh and assumes a ' +
-                     'constant density (mass/full_volume)')
+                     'used for calculating the inertia matrix.')
         wec_im.inertia_matrix = wec_im.compute_rigid_body_inertia(rho=rho)
     wec_im = wec_im.keep_immersed_part()
     wec_im.name = f"{wec_im.name}_immersed"

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2177,7 +2177,7 @@ def run_bem(
                       'wavelength': False,
                       'wavenumber': False,
                      }
-    wec_im = fb.copy(name=f"{fb.name}_immersed").keep_immersed_part()
+    wec_im = fb.copy(name=fb.name)
     wec_im = set_fb_centers(wec_im, rho=rho)
     if not hasattr(wec_im, 'inertia_matrix'):
         _log.warning('FloatingBody has no inertia_matrix field. ' + 
@@ -2186,6 +2186,7 @@ def run_bem(
                      'Otherwise, the neutral buoyancy assumption will ' + 
                      'be used to auto-populate.')
         wec_im.inertia_matrix = wec_im.compute_rigid_body_inertia(rho=rho)
+    wec_im = fb.copy(name=f"{fb.name}_immersed").keep_immersed_part()
     if not hasattr(wec_im, 'hydrostatic_stiffness'):
         _log.warning('FloatingBody has no hydrostatic_stiffness field. ' +
                      'Capytaine will auto-populate the hydrostatic ' +

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2177,16 +2177,17 @@ def run_bem(
                       'wavelength': False,
                       'wavenumber': False,
                      }
-    wec_im = fb.copy(name=fb.name)
+    wec_im = fb.copy(name=f"{fb.name}_immersed").keep_immersed_part()
     wec_im = set_fb_centers(wec_im, rho=rho)
     if not hasattr(wec_im, 'inertia_matrix'):
         _log.warning('FloatingBody has no inertia_matrix field. ' + 
                      'If the FloatingBody mass is defined, it will be ' + 
                      'used for calculating the inertia matrix here. ' + 
                      'Otherwise, the neutral buoyancy assumption will ' + 
-                     'be used to auto-populate.')
+                     'be used to auto-populate (inertial properties ' +
+                     'based only on the immersed part). We recommend ' +
+                     'inputting the correct inertial properties.')
         wec_im.inertia_matrix = wec_im.compute_rigid_body_inertia(rho=rho)
-    wec_im = wec_im.copy(name=f"{wec_im.name}_immersed").keep_immersed_part()
     if not hasattr(wec_im, 'hydrostatic_stiffness'):
         _log.warning('FloatingBody has no hydrostatic_stiffness field. ' +
                      'Capytaine will auto-populate the hydrostatic ' +

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2180,7 +2180,7 @@ def run_bem(
     wec_im = fb.copy()
     wec_im = set_fb_centers(wec_im, rho=rho)
     if not hasattr(wec_im, 'inertia_matrix'):
-        if not hasattr(wec_im, 'mass'):
+        if wec_im.mass is None:
             wec_im.mass = rho*wec_im.copy().keep_immersed_part().volume
             _log.warning('FloatingBody has no inertia_matrix field. ' + 
                      'The FloatingBody mass is defined and will be ' +

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2587,7 +2587,10 @@ def set_fb_centers(
                 def_val = fb.center_of_mass
                 log_str = (
                     "Using the center of gravity (COG) as the rotation center " +
-                    "for hydrostatics.")
+                    "for hydrostatics. Note that the hydrostatics do not use the " +
+                    "axes defined by the Floating Body degrees of freedom, and the " + 
+                    "rotation center should be set manually when using Capytaine to " + 
+                    "calculate hydrostatics about an axis other than the COG.")
             setattr(fb, property, def_val)
             _log.warning(log_str)
         elif getattr(fb, property) is not None:

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2186,7 +2186,7 @@ def run_bem(
                      'Otherwise, the neutral buoyancy assumption will ' + 
                      'be used to auto-populate.')
         wec_im.inertia_matrix = wec_im.compute_rigid_body_inertia(rho=rho)
-    wec_im = fb.copy(name=f"{fb.name}_immersed").keep_immersed_part()
+    wec_im = wec_im.copy(name=f"{wec_im.name}_immersed").keep_immersed_part()
     if not hasattr(wec_im, 'hydrostatic_stiffness'):
         _log.warning('FloatingBody has no hydrostatic_stiffness field. ' +
                      'Capytaine will auto-populate the hydrostatic ' +


### PR DESCRIPTION
## Description
Capytaine's `compute_rigid_body_inertia()` function calculates the density as:
``` 
density = rho if self.mass is None else self.mass/volume
```
So, I think we can handle it on the WecOptTool side. The approach would be to define the mass in WecOptTool based on the immersed part, then pass in the full mesh to `compute_rigid_body_inertia()` which will use the mass/volume as the density to calculate the correct inertia values.

Resolves #399 

I've updated the process and warning messages to reflect this.
