### PR TITLE
Use Capytaine's immersed_part() instead of keep_immersed_part()

### DIFF
--- a/examples/tutorial_3_LUPA.ipynb
+++ b/examples/tutorial_3_LUPA.ipynb
@@ -344,7 +344,7 @@
     "lupa_fb.inertia_matrix = rigid_inertia_matrix_xr\n",
     "\n",
     "# Calculate hydrostatic stiffness after keeping immersed value\n",
-    "lupa_fb = lupa_fb.keep_immersed_part()\n",
+    "lupa_fb = lupa_fb.immersed_part()\n",
     "lupa_fb.hydrostatic_stiffness = lupa_fb.compute_hydrostatic_stiffness(rho=rho)"
    ]
   },

--- a/examples/tutorial_4_Pioneer.ipynb
+++ b/examples/tutorial_4_Pioneer.ipynb
@@ -286,7 +286,7 @@
     "bem_data_irreg = wot.run_bem(pnr_fb, freq_irreg)\n",
     "omega_irreg = bem_data_irreg.omega.values\n",
     "\n",
-    "pnr_fb.keep_immersed_part()\n",
+    "pnr_fb.immersed_part()\n",
     "k_buoy = pnr_fb.compute_hydrostatic_stiffness(rho=rho).values.squeeze()\n",
     "k_spring = spring_properties['Max torque'] / spring_properties['Max displacement']\n",
     "print(f'Hydrostatic stiffness from Capytaine: {k_buoy} N-m/rad')\n",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -136,7 +136,7 @@ def wec_from_impedance(hydro_data, pto, fb):
     B = bemc['radiation_damping'].values
     fb.center_of_mass = [0, 0, 0]
     fb.rotation_center = fb.center_of_mass
-    fb = fb.copy(name=f"{fb.name}_immersed").keep_immersed_part()
+    fb = fb.immersed_part()
     mass = bemc['inertia_matrix'].values
     hstiff = bemc['hydrostatic_stiffness'].values
     K = np.expand_dims(hstiff, 2)

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -2127,7 +2127,7 @@ def run_bem(
     :py:func:`wecopttool.change_bem_convention`).
 
     It creates the *test matrix*, calls
-    :py:meth:`capytaine.bodies.bodies.FloatingBody.keep_immersed_part`,
+    :py:meth:`capytaine.bodies.bodies.FloatingBody.immersed_part`,
     calls :py:meth:`capytaine.bem.solver.BEMSolver.fill_dataset`,
     and changes the sign convention using
     :py:func:`wecopttool.change_bem_convention`.
@@ -2184,7 +2184,7 @@ def run_bem(
     wec_im = set_fb_centers(wec_im, rho=rho)
     if not hasattr(wec_im, 'inertia_matrix'):
         if wec_im.mass is None:
-            wec_im.mass = rho*wec_im.copy().keep_immersed_part().volume
+            wec_im.mass = rho*wec_im.immersed_part().volume
             _log.warning('FloatingBody has no inertia_matrix or mass ' +
                      'field. The mass will be calculated based on a ' +
                      'neutral buoyancy assumption. The inertia matrix ' +
@@ -2195,7 +2195,7 @@ def run_bem(
                      'The FloatingBody mass is defined and will be ' +
                      'used for calculating the inertia matrix.')
         wec_im.inertia_matrix = wec_im.compute_rigid_body_inertia(rho=rho)
-    wec_im = wec_im.keep_immersed_part()
+    wec_im = wec_im.immersed_part()
     wec_im.name = f"{wec_im.name}_immersed"
     if not hasattr(wec_im, 'hydrostatic_stiffness'):
         _log.warning('FloatingBody has no hydrostatic_stiffness field. ' +


### PR DESCRIPTION
## Description
This PR updates the tutorials and core to use the `immersed_part()` function instead of `keep_immersed_part()`. This aligns with the latest versions of Capytaine. See comments in #417 
