### PR TITLE
Fix conf.py file to not ignore np or npz

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,7 +93,7 @@ def all_but_ipynb(dir, contents):
 def all_but_nc(dir, contents):
     result = []
     for c in contents:
-        if not c.endswith(".nc") or not c.endswith(".npz"):
+        if not (c.endswith(".nc") or c.endswith(".npz")):
             result += [c]
     return result
 


### PR DESCRIPTION
## Description
This PR fixes the conf.py file to not ignore .np or .npz files. 