### PR TITLE
Remove the numpy restrictions and fix issues with coverage/coveralls

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,13 +42,13 @@ jobs:
       run: |
         conda activate test-env
         python3 -m pip install --upgrade pip
-        pip3 install gmsh pygmsh coveralls pytest pytest-cov
+        pip3 install gmsh pygmsh coveralls pytest
         pip3 install .
 
     # run all tests & coverage
     - name: Run Test
       shell: bash -l {0}
-      run: pytest --cov=wecopttool --cov-report=xml
+      run: coverage run -m pytest
 
     # upload coverage data
     - name: Upload coverage data to coveralls.io

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,13 +41,13 @@ jobs:
       run: |
         conda activate test-env
         python3 -m pip install --upgrade pip
-        pip3 install gmsh pygmsh coveralls pytest pytest-cov
+        pip3 install gmsh pygmsh coveralls pytest
         pip3 install .
 
     # run all tests & coverage
     - name: Run Test
       shell: bash -l {0}
-      run: pytest --cov=wecopttool --cov-report=xml
+      run: coverage run -m pytest
 
     # upload coverage data
     - name: Upload coverage data to coveralls.io

--- a/examples/tutorial_2_AquaHarmonics.ipynb
+++ b/examples/tutorial_2_AquaHarmonics.ipynb
@@ -309,7 +309,7 @@
     "y = np.arange(-1*torque_max, 1.0*torque_max, 5)\n",
     "X, Y = np.meshgrid(x, y)\n",
     "Z = power_loss(X, Y).copy()/1e3\n",
-    "Z[np.abs(X*Y) > power_max] = np.NaN  # cut off area outside of power limit\n",
+    "Z[np.abs(X*Y) > power_max] = np.nan  # cut off area outside of power limit\n",
     "\n",
     "fig = plt.figure(figsize=plt.figaspect(0.4))\n",
     "ax = [fig.add_subplot(1, 2, 1, projection=\"3d\"),\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,8 @@ geometry = [
     "gmsh",
     "pygmsh",
 ]
+
+[tool.coverage.run]
+source = [
+    "wecopttool",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "numpy>=1.20, <2.0",
+    "numpy",
     "scipy",
     "xarray",
     "jax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "numpy",
+    "numpy>=1.20",
     "scipy",
     "xarray",
     "jax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wecopttool"
-version = "3.2.0"
+version = "3.2.1"
 description = "WEC Design Optimization Toolbox"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Description
This PR removes the numpy restrictions (see #391) which were a result of autograd being outdated. Since we switched to jax, this update is relatively straightforward but did require switching `np.NaN` to `np.nan` in the AH example.

This PR also address coverage issues that we've been having. By reverting back to `coverage` instead of `pytest-cov`, the coverage data will actually be uploaded to coveralls (instead of displaying as 0%). I also added 
```
[tool.coverage.run]
source = [
    "wecopttool",
]
``` 
to pyproject.toml, which specifies only coverage for files in the source directory should be recorded. This fixes an error with the ubuntu tests trying to find some _netcdf4.pyx file.

## Type of PR
- [X] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [X] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [X] The pull request is from an issue branch (not main) on *your* fork, to the [dev branch in WecOptTool](https://github.com/sandialabs/WecOptTool/tree/dev).
- [X] The authors have given the admins edit access
- [X] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [ ] Modified the documentation if applicable
- [ ] Modified or added a new test
- [ ] All tests pass
- [ ] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
