### PR TITLE
add 'geometry' dependencies to 'dev'

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,7 +92,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         pip3 install wheel coveralls
-        pip3 install -e .[dev,geometry]
+        pip3 install -e .[dev]
 
     - name: Build documentation
       shell: bash -l {0}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -90,7 +90,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         pip3 install wheel coveralls
-        pip3 install -e .[dev,geometry]
+        pip3 install -e .[dev]
 
     - name: Build documentation
       shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         pip3 install wheel coveralls
-        pip3 install -e .[dev,geometry]
+        pip3 install -e .[dev]
 
     - name: Build documentation
       shell: bash -l {0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pygifsicle",
     "jinja2",
     "nbconvert",
+    "wecopttool[geometry]",
 ]
 
 geometry = [


### PR DESCRIPTION
The optional dependencies for `dev` should probably include all dependencies to run all tests with no skipping, right?
