### PR TITLE
future proofing the post_process method to account for missing zero frequency in wave

### DIFF
--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -964,7 +964,7 @@ class WEC:
                 attrs={"time_created_utc": create_time}
             )
 
-            results_fd = xr.merge([fd_state, fd_forces, wave])
+            results_fd = xr.merge([fd_state, fd_forces, wave], join="outer", compat="no_conflicts")
             results_fd = results_fd.transpose('omega', 'influenced_dof', 'type',
                                             'wave_direction')
             results_fd = results_fd.fillna(0)
@@ -988,8 +988,8 @@ class WEC:
         results_td_list = []
         for idx, ires in enumerate(res):
             ifd, itd = _postproc(ires, waves.sel(realization=idx), nsubsteps)
-            ifd.expand_dims({'realization':[ires]})
-            itd.expand_dims({'realization':[ires]})
+            ifd = ifd.expand_dims(realization=[idx])
+            itd = itd.expand_dims(realization=[idx])
             results_fd_list.append(ifd)
             results_td_list.append(itd)
         results_fd = xr.concat(results_fd_list, dim='realization')


### PR DESCRIPTION
I received FutureWarnings during the merge in post_process.
The wave is always missing the zero frequency. 

There is a simple fix:
join="outer" keeps the union of frequency values
compat='no_conflicts': allows “fill in missing” but no contradictions.

Further,
ifd.expand_dims({'realization':[ires]})
itd.expand_dims({'realization':[ires]})
did nothing.

Now changed so that the dimension is added before the concatenation (the concatenation actually expanded the dims)

## Description
Concise description of the pull request with references to any [issues](https://github.com/sandialabs/WecOptTool/issues).

## Type of PR
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/sandialabs/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on *your* fork, to the [dev branch in WecOptTool](https://github.com/sandialabs/WecOptTool/tree/dev).
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Modified the documentation if applicable
- [x] Modified or added a new test
- [x] All tests pass
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Additional details
Include any relevant context and describe any validation and verification efforts.
