### PR TITLE
Restrict capytaine to v2.3.1 for now (dev)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "scipy",
     "xarray",
     "jax",
-    "capytaine",
+    "capytaine==2.3.1",
     "joblib",
     "wavespectra>=4.0",
     "netcdf4",


### PR DESCRIPTION
## Description
There are some issues with our tutorials' compatibility with Capytaine's newly released v3.0. These issues are being resolved in PR #454. In the meantime, this restricts WecOptTool to install with v2.3.1. 